### PR TITLE
Adding dynamic device selection to boot process for BBB/MBM2

### DIFF
--- a/include/configs/beaglebone-black.h
+++ b/include/configs/beaglebone-black.h
@@ -16,10 +16,6 @@
 * beaglebone-black.h
 *
 * Configuration file for the Beaglebone Black for Kubos
-*
-* Note: By default, KubOS Linux will be booted from the eMMC storage. This is defined
-* to the system as the SECOND MMC device. The microSD card is defined as the FIRST MMC
-* device.
 */
 
 #pragma once
@@ -30,6 +26,7 @@
 /* Undo things we don't want to include from the base Beaglebone Black configuration */
 #undef CONFIG_SYS_LDSCRIPT /* For NOR flash, which we (and the BBB) don't support */
 #undef CONFIG_BOOTCOMMAND
+#undef BOOT_TARGET_DEVICES
 #undef CONFIG_EXTRA_ENV_SETTINGS
 #undef CONFIG_ENV_IS_IN_MMC
 #undef CONFIG_ENV_IS_IN_FAT
@@ -66,12 +63,12 @@
 
 /* DFU Configuration */
 #define DFU_ALT_INFO_MMC \
-	"dfu_alt_info_mmc=" 		\
-	"kernel fat 1 1;" 		\
-	"rootfs part 1 2;" \
-	"uboot fat 1 1;" \
-	"dtb fat 1 1" \
-	"\0"
+    "dfu_alt_info_mmc="         \
+    "kernel fat 1 1;"       \
+    "rootfs part 1 2;" \
+    "uboot fat 1 1;" \
+    "dtb fat 1 1" \
+    "\0"
 
 #define DFU_ALT_INFO_NOR ""
 #else
@@ -80,17 +77,43 @@
 #endif /* CONFIG_UPDATE_KUBOS */
 
 #define CONFIG_BOOTCOMMAND \
-	"setenv bootargs console=ttyS0,115200 root=/dev/mmcblk${boot_dev}p2 ext4 rootwait; " \
-	"fatload mmc ${boot_dev}:1 ${fdtaddr} /beaglebone-black.dtb; " \
-	"fatload mmc ${boot_dev}:1 ${loadaddr} /kernel; " \
-	"bootm ${loadaddr} - ${fdtaddr}"
+    "run distro_bootcmd"
+
+#define BOOT_TARGET_DEVICES(func) \
+    func(LEGACY_MMC, legacy_mmc, "${boot_dev}")
+    func(LEGACY_MMC, legacy_mmc, 0) \
+    func(LEGACY_MMC, legacy_mmc, 1) \
 
 #ifndef CONFIG_SPL_BUILD
 #define CONFIG_EXTRA_ENV_SETTINGS \
-	"boot_dev=1\0" \
-	DEFAULT_LINUX_BOOT_ENV \
-	NETARGS \
-	BOOTENV \
-	KUBOS_UPDATE_ARGS
+    DEFAULT_LINUX_BOOT_ENV \
+    "mmcdev=0\0" \
+    "mmcrootfstype=ext4 rootwait\0" \
+    "finduuid=part uuid mmc ${bootpart} uuid\0" \
+    "args_mmc=run finduuid;setenv bootargs console=${console} " \
+        "${optargs} " \
+        "root=PARTUUID=${uuid} ro " \
+        "rootfstype=${mmcrootfstype}\0" \
+    "bootfile=kernel\0" \
+    "console=ttyS0,115200\0" \
+    "optargs=\0" \
+    "loadimage=fatload mmc ${mmcdev}:1 ${loadaddr} /${bootfile}\0" \
+    "loadfdt=fatload mmc ${mmcdev}:1 ${fdtaddr} /${board}.dtb\0" \
+    "mmcloados=run args_mmc; " \
+        "if run loadfdt; then " \
+            "bootm ${loadaddr} - ${fdtaddr}; " \
+        "else " \
+            "echo ERROR: Failed to load ${board}.dtb; " \
+        "fi;\0" \
+    "mmcboot=mmc dev ${mmcdev}; " \
+        "if mmc rescan; then " \
+            "echo SD/MMC found on device ${mmcdev};" \
+            "if run loadimage; then " \
+                "run mmcloados;" \
+            "fi;" \
+        "fi;\0" \
+    NETARGS \
+    BOOTENV \
+    KUBOS_UPDATE_ARGS
 #endif
 

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -17,10 +17,6 @@
 *
 * Configuration file for the Pumpkin Motherboard Module 2, using a Beaglebone Black
 * as the OBC.
-*
-* Note: By default, KubOS Linux will be booted from the eMMC storage. This is defined
-* to the system as the SECOND MMC device. The microSD card is defined as the FIRST MMC
-* device.
 */
 
 #pragma once
@@ -81,7 +77,6 @@
 #define DFU_ALT_INFO_NOR ""
 #endif /* CONFIG_UPDATE_KUBOS */
 
-/*TODO: check for boot_dev */
 #define CONFIG_BOOTCOMMAND \
     "run distro_bootcmd"
 

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -102,13 +102,13 @@
     "bootfile=kernel\0" \
     "console=ttyS0,115200\0" \
     "optargs=\0" \
-    "loadimage=fatload mmc ${bootpart} ${loadaddr} /${bootfile}\0" \
-    "loadfdt=fatload mmc ${bootpart} ${fdtaddr} /${board}.dtb\0" \
+    "loadimage=fatload mmc ${mmcdev}:1 ${loadaddr} /${bootfile}\0" \
+    "loadfdt=fatload mmc ${mmcdev}:1 ${fdtaddr} /${board}.dtb\0" \
     "mmcloados=run args_mmc; " \
         "if run loadfdt; then " \
             "bootm ${loadaddr} - ${fdtaddr}; " \
         "else " \
-            "echo ERROR: Failed to load ${target}.dtb; " \
+            "echo ERROR: Failed to load ${board}.dtb; " \
         "fi;\0" \
     "mmcboot=mmc dev ${mmcdev}; " \
         "if mmc rescan; then " \

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -30,7 +30,7 @@
 
 /* Undo things we don't want to include from the base Beaglebone Black configuration */
 #undef CONFIG_SYS_LDSCRIPT /* For NOR flash, which we (and the BBB) don't support */
-#undef CONFIG_BOOTCOMMAND
+#undef BOOT_TARGET_DEVICES
 #undef CONFIG_EXTRA_ENV_SETTINGS
 #undef CONFIG_ENV_IS_IN_MMC
 #undef CONFIG_ENV_IS_IN_FAT
@@ -80,16 +80,41 @@
 #define DFU_ALT_INFO_NOR ""
 #endif /* CONFIG_UPDATE_KUBOS */
 
-#define CONFIG_BOOTCOMMAND \
-	"setenv bootargs console=ttyS0,115200 root=/dev/mmcblk${boot_dev}p2 ext4 rootwait; " \
-	"fatload mmc ${boot_dev}:1 ${fdtaddr} /pumpkin-mbm2.dtb; " \
-	"fatload mmc ${boot_dev}:1 ${loadaddr} /kernel; " \
-	"bootm ${loadaddr} - ${fdtaddr}"
+//TODO: check for boot_dev before running through list of boot targets
+
+#define BOOT_TARGET_DEVICES(func) \
+    func(LEGACY_MMC, legacy_mmc, 0) \
+    func(LEGACY_MMC, legacy_mmc, 1) \
 
 #ifndef CONFIG_SPL_BUILD
 #define CONFIG_EXTRA_ENV_SETTINGS \
-	"boot_dev=1\0" \
-	DEFAULT_LINUX_BOOT_ENV \
+    DEFAULT_LINUX_BOOT_ENV \
+    "mmcdev=0\0" \
+    "mmcrootfstype=ext4 rootwait\0" \
+    "finduuid=part uuid mmc ${bootpart} uuid\0" \
+    "args_mmc=run finduuid;setenv bootargs console=${console} " \
+        "${optargs} " \
+        "root=PARTUUID=${uuid} ro " \
+        "rootfstype=${mmcrootfstype}\0" \
+    "bootfile=kernel\0" \
+    "target=pumpkin-mbm2\0" \
+    "console=ttyS0,115200\0" \
+    "optargs=\0" \
+    "loadimage=fatload mmc ${bootpart} ${loadaddr} /${bootfile}\0" \
+    "loadfdt=fatload mmc ${bootpart} ${fdtaddr} /${target}.dtb\0" \
+    "mmcloados=run args_mmc; " \
+        "if run loadfdt; then " \
+            "bootm ${loadaddr} - ${fdtaddr}; " \
+        "else " \
+            "echo ERROR: Failed to load ${target}.dtb; " \
+        "fi; " \
+    "mmcboot=mmc dev ${mmcdev}; " \
+        "if mmc rescan; then " \
+            "echo SD/MMC found on device ${mmcdev};" \
+            "if run loadimage; then " \
+                "run mmcloados;" \
+            "fi;" \
+        "fi;\0" \
 	NETARGS \
 	BOOTENV \
 	KUBOS_UPDATE_ARGS

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -30,6 +30,7 @@
 
 /* Undo things we don't want to include from the base Beaglebone Black configuration */
 #undef CONFIG_SYS_LDSCRIPT /* For NOR flash, which we (and the BBB) don't support */
+#undef CONFIG_BOOTCOMMAND
 #undef BOOT_TARGET_DEVICES
 #undef CONFIG_EXTRA_ENV_SETTINGS
 #undef CONFIG_ENV_IS_IN_MMC
@@ -80,7 +81,9 @@
 #define DFU_ALT_INFO_NOR ""
 #endif /* CONFIG_UPDATE_KUBOS */
 
-//TODO: check for boot_dev before running through list of boot targets
+/*TODO: check for boot_dev */
+#define CONFIG_BOOTCOMMAND \
+    "run distro_bootcmd"
 
 #define BOOT_TARGET_DEVICES(func) \
     func(LEGACY_MMC, legacy_mmc, 0) \
@@ -97,17 +100,16 @@
         "root=PARTUUID=${uuid} ro " \
         "rootfstype=${mmcrootfstype}\0" \
     "bootfile=kernel\0" \
-    "target=pumpkin-mbm2\0" \
     "console=ttyS0,115200\0" \
     "optargs=\0" \
     "loadimage=fatload mmc ${bootpart} ${loadaddr} /${bootfile}\0" \
-    "loadfdt=fatload mmc ${bootpart} ${fdtaddr} /${target}.dtb\0" \
+    "loadfdt=fatload mmc ${bootpart} ${fdtaddr} /${board}.dtb\0" \
     "mmcloados=run args_mmc; " \
         "if run loadfdt; then " \
             "bootm ${loadaddr} - ${fdtaddr}; " \
         "else " \
             "echo ERROR: Failed to load ${target}.dtb; " \
-        "fi; " \
+        "fi;\0" \
     "mmcboot=mmc dev ${mmcdev}; " \
         "if mmc rescan; then " \
             "echo SD/MMC found on device ${mmcdev};" \


### PR DESCRIPTION
This PR takes advantage of the existing TI/AM335x code to dynamically detect which device to boot from. It first tries MMC0 (the microsd card) and then, if that fails, tries to boot from MMC1 (the EMMC).

Once the successful device has been found, the partuuid is passed to Linux to be used to mount the rootfs, rather than a hardcoded device name.

This PR is coupled with kubos/kubos-linux-build#83 to fix the issue where booting with an empty microsd slot would cause the system to hang.