### PR TITLE
Fixing Atmel SPI timing bug

### DIFF
--- a/drivers/spi/atmel_spi.c
+++ b/drivers/spi/atmel_spi.c
@@ -186,13 +186,13 @@ int spi_xfer(struct spi_slave *slave, unsigned int bitlen,
 		}
 
 		/*
-		 * Kubos: Updating to also check for the TXEMPTY bit, which indicates that the
-		 * transfer shift register is also empty. This prevents a timing issue between
+		 * Kubos: Updating to check for the TXEMPTY bit (vs TDRE), which indicates that the
+		 * transfer data *and shift* registers are empty. This prevents a timing issue between
 		 * writing and reading that can occur.
 		 * If this driver is ever updated to allow the SPI bus to operate in slave mode,
 		 * this logic will need to be changed since TXEMPTY isn't used in that mode.
 		 */
-		if (len_tx < len && (status & ATMEL_SPI_SR_TDRE) && (status & ATMEL_SPI_SR_TXEMPTY)) {
+		if (len_tx < len && (status & ATMEL_SPI_SR_TXEMPTY)) {
 			if (txp)
 				value = *txp++;
 			else

--- a/drivers/spi/atmel_spi.c
+++ b/drivers/spi/atmel_spi.c
@@ -185,7 +185,14 @@ int spi_xfer(struct spi_slave *slave, unsigned int bitlen,
 			len_rx++;
 		}
 
-		if (len_tx < len && (status & ATMEL_SPI_SR_TDRE)) {
+		/*
+		 * Kubos: Updating to also check for the TXEMPTY bit, which indicates that the
+		 * transfer shift register is also empty. This prevents a timing issue between
+		 * writing and reading that can occur.
+		 * If this driver is ever updated to allow the SPI bus to operate in slave mode,
+		 * this logic will need to be changed since TXEMPTY isn't used in that mode.
+		 */
+		if (len_tx < len && (status & ATMEL_SPI_SR_TDRE) && (status & ATMEL_SPI_SR_TXEMPTY)) {
 			if (txp)
 				value = *txp++;
 			else


### PR DESCRIPTION
Found a condition where the SPI bus' read buffer overrun bit was being set repeatedly. Multiple write were occurring before a single read, leading to the problem.

The TX architecture:
```
SPI bus - 
 my_tx_byte -> TX Buffer Register -> TX Shift Register -> SPI slave
```
The code places a byte to be transferred into the buffer register. The data is then copied into the shift register, which sends each bit to the slave using the clock cycle.

The `TDRE` status bit indicates that the contents of the buffer register have been sent to the shift register, so the buffer register is now empty.

The `TXEMPTY` status bit indicates that the buffer register *and the shift register* are empty, meaning that an entire byte has been successfully transferred. Waiting for this state clears up the issue and returns the bus back to its preferred write/read/write/read state.