### PR TITLE
Updating BBB/MBM2 configs for new envar location

### DIFF
--- a/include/configs/beaglebone-black.h
+++ b/include/configs/beaglebone-black.h
@@ -47,7 +47,7 @@
 #define CONFIG_ENV_IS_IN_EXT4    1
 #define EXT4_ENV_INTERFACE       "mmc"
 #define EXT4_ENV_DEVICE_AND_PART "1:3"
-#define EXT4_ENV_FILE            "/system/etc/uboot.env"
+#define EXT4_ENV_FILE            "/uboot.env"
 #define CONFIG_ENV_SIZE         10 * 1024 /* Assume sector size of 1024 */
 #endif
 #endif /* CONFIG_SPL_BUILD */

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -48,7 +48,7 @@
 #define CONFIG_ENV_IS_IN_EXT4    1
 #define EXT4_ENV_INTERFACE       "mmc"
 #define EXT4_ENV_DEVICE_AND_PART "1:3"
-#define EXT4_ENV_FILE            "/system/etc/uboot.env"
+#define EXT4_ENV_FILE            "/uboot.env"
 #define CONFIG_ENV_SIZE         10 * 1024 /* Assume sector size of 1024 */
 #endif
 #endif /* CONFIG_SPL_BUILD */


### PR DESCRIPTION
This PR updates the BBB and MBM2 configs to change the file system location of the U-Boot envar file.
The file is now in its own partition with no subdirectories.

The partition number remained the same (the user partition which was the old 3rd partition was bumped down a number), so no other changes are required.

These changes are coupled with kubos/kubos-linux-build#141