### PR TITLE
Moving iOBC envar partition

### DIFF
--- a/include/configs/at91sam9g20isis.h
+++ b/include/configs/at91sam9g20isis.h
@@ -168,8 +168,8 @@
 /* u-boot env in sd/mmc card */
 #define CONFIG_ENV_IS_IN_EXT4	1
 #define EXT4_ENV_INTERFACE	   "mmc"
-#define EXT4_ENV_DEVICE_AND_PART "0:1"
-#define EXT4_ENV_FILE			"/system/etc/uboot.env"
+#define EXT4_ENV_DEVICE_AND_PART "0:8"
+#define EXT4_ENV_FILE			"/uboot.env"
 #define CONFIG_ENV_SIZE		 1 * 1024 //Assume sector size of 1024
 #endif
 


### PR DESCRIPTION
This PR updates the iOBC to change the file system location of the U-Boot envar file.
The file is now in its own partition with no subdirectories.

These changes are coupled with kubos/kubos-linux-build#142