### PR TITLE
Reducing RAM overhead for OS upgrade/recovery

### DIFF
--- a/common/image-fit.c
+++ b/common/image-fit.c
@@ -1038,33 +1038,13 @@ static int fit_image_check_hash(const void *fit, int noffset, const void *data,
 	return 0;
 }
 
-/**
- * fit_image_verify - verify data integrity
- * @fit: pointer to the FIT format image header
- * @image_noffset: component image node offset
- *
- * fit_image_verify() goes over component image hash nodes,
- * re-calculates each data hash and compares with the value stored in hash
- * node.
- *
- * returns:
- *     1, if all hashes are valid
- *     0, otherwise (or on error)
- */
-int fit_image_verify(const void *fit, int image_noffset)
+int fit_image_verify_with_data(const void *fit, int image_noffset,
+			       const void *data, size_t size)
 {
-	const void	*data;
-	size_t		size;
 	int		noffset = 0;
 	char		*err_msg = "";
 	int verify_all = 1;
 	int ret;
-
-	/* Get image data and data length */
-	if (fit_image_get_data(fit, image_noffset, &data, &size)) {
-		err_msg = "Can't get image data/size";
-		goto error;
-	}
 
 	/* Verify all required signatures */
 	if (IMAGE_ENABLE_VERIFY &&
@@ -1120,6 +1100,38 @@ error:
 	       err_msg, fit_get_name(fit, noffset, NULL),
 	       fit_get_name(fit, image_noffset, NULL));
 	return 0;
+}
+
+/**
+ * fit_image_verify - verify data integrity
+ * @fit: pointer to the FIT format image header
+ * @image_noffset: component image node offset
+ *
+ * fit_image_verify() goes over component image hash nodes,
+ * re-calculates each data hash and compares with the value stored in hash
+ * node.
+ *
+ * returns:
+ *     1, if all hashes are valid
+ *     0, otherwise (or on error)
+ */
+int fit_image_verify(const void *fit, int image_noffset)
+{
+	const void	*data;
+	size_t		size;
+	int		noffset = 0;
+	char		*err_msg = "";
+
+	/* Get image data and data length */
+	if (fit_image_get_data(fit, image_noffset, &data, &size)) {
+		err_msg = "Can't get image data/size";
+		printf("error!\n%s for '%s' hash node in '%s' image node\n",
+		       err_msg, fit_get_name(fit, noffset, NULL),
+		       fit_get_name(fit, image_noffset, NULL));
+		return 0;
+	}
+
+	return fit_image_verify_with_data(fit, image_noffset, data, size);
 }
 
 /**

--- a/common/image-fit.c
+++ b/common/image-fit.c
@@ -6,7 +6,7 @@
  * (C) Copyright 2000-2006
  * Wolfgang Denk, DENX Software Engineering, wd@denx.de.
  *
- * SPDX-License-Identifier:	GPL-2.0+
+ * SPDX-License-Identifier: GPL-2.0+
  */
 
 #ifdef USE_HOSTCC
@@ -33,23 +33,23 @@ DECLARE_GLOBAL_DATA_PTR;
 /*****************************************************************************/
 #ifndef USE_HOSTCC
 static int fit_parse_spec(const char *spec, char sepc, ulong addr_curr,
-		ulong *addr, const char **name)
+        ulong *addr, const char **name)
 {
-	const char *sep;
+    const char *sep;
 
-	*addr = addr_curr;
-	*name = NULL;
+    *addr = addr_curr;
+    *name = NULL;
 
-	sep = strchr(spec, sepc);
-	if (sep) {
-		if (sep - spec > 0)
-			*addr = simple_strtoul(spec, NULL, 16);
+    sep = strchr(spec, sepc);
+    if (sep) {
+        if (sep - spec > 0)
+            *addr = simple_strtoul(spec, NULL, 16);
 
-		*name = sep + 1;
-		return 1;
-	}
+        *name = sep + 1;
+        return 1;
+    }
 
-	return 0;
+    return 0;
 }
 
 /**
@@ -74,9 +74,9 @@ static int fit_parse_spec(const char *spec, char sepc, ulong addr_curr,
  *     0 otherwise
  */
 int fit_parse_conf(const char *spec, ulong addr_curr,
-		ulong *addr, const char **conf_name)
+        ulong *addr, const char **conf_name)
 {
-	return fit_parse_spec(spec, '#', addr_curr, addr, conf_name);
+    return fit_parse_spec(spec, '#', addr_curr, addr, conf_name);
 }
 
 /**
@@ -100,18 +100,18 @@ int fit_parse_conf(const char *spec, ulong addr_curr,
  *     0 otherwise
  */
 int fit_parse_subimage(const char *spec, ulong addr_curr,
-		ulong *addr, const char **image_name)
+        ulong *addr, const char **image_name)
 {
-	return fit_parse_spec(spec, ':', addr_curr, addr, image_name);
+    return fit_parse_spec(spec, ':', addr_curr, addr, image_name);
 }
 #endif /* !USE_HOSTCC */
 
 static void fit_get_debug(const void *fit, int noffset,
-		char *prop_name, int err)
+        char *prop_name, int err)
 {
-	debug("Can't get '%s' property from FIT 0x%08lx, node: offset %d, name %s (%s)\n",
-	      prop_name, (ulong)fit, noffset, fit_get_name(fit, noffset, NULL),
-	      fdt_strerror(err));
+    debug("Can't get '%s' property from FIT 0x%08lx, node: offset %d, name %s (%s)\n",
+          prop_name, (ulong)fit, noffset, fit_get_name(fit, noffset, NULL),
+          fdt_strerror(err));
 }
 
 /**
@@ -124,21 +124,21 @@ static void fit_get_debug(const void *fit, int noffset,
  */
 int fit_get_subimage_count(const void *fit, int images_noffset)
 {
-	int noffset;
-	int ndepth;
-	int count = 0;
+    int noffset;
+    int ndepth;
+    int count = 0;
 
-	/* Process its subnodes, print out component images details */
-	for (ndepth = 0, count = 0,
-		noffset = fdt_next_node(fit, images_noffset, &ndepth);
-	     (noffset >= 0) && (ndepth > 0);
-	     noffset = fdt_next_node(fit, noffset, &ndepth)) {
-		if (ndepth == 1) {
-			count++;
-		}
-	}
+    /* Process its subnodes, print out component images details */
+    for (ndepth = 0, count = 0,
+        noffset = fdt_next_node(fit, images_noffset, &ndepth);
+         (noffset >= 0) && (ndepth > 0);
+         noffset = fdt_next_node(fit, noffset, &ndepth)) {
+        if (ndepth == 1) {
+            count++;
+        }
+    }
 
-	return count;
+    return count;
 }
 
 #if !defined(CONFIG_SPL_BUILD) || defined(CONFIG_FIT_SPL_PRINT)
@@ -156,91 +156,91 @@ int fit_get_subimage_count(const void *fit, int images_noffset)
  */
 void fit_print_contents(const void *fit)
 {
-	char *desc;
-	char *uname;
-	int images_noffset;
-	int confs_noffset;
-	int noffset;
-	int ndepth;
-	int count = 0;
-	int ret;
-	const char *p;
-	time_t timestamp;
+    char *desc;
+    char *uname;
+    int images_noffset;
+    int confs_noffset;
+    int noffset;
+    int ndepth;
+    int count = 0;
+    int ret;
+    const char *p;
+    time_t timestamp;
 
-	/* Indent string is defined in header image.h */
-	p = IMAGE_INDENT_STRING;
+    /* Indent string is defined in header image.h */
+    p = IMAGE_INDENT_STRING;
 
-	/* Root node properties */
-	ret = fit_get_desc(fit, 0, &desc);
-	printf("%sFIT description: ", p);
-	if (ret)
-		printf("unavailable\n");
-	else
-		printf("%s\n", desc);
+    /* Root node properties */
+    ret = fit_get_desc(fit, 0, &desc);
+    printf("%sFIT description: ", p);
+    if (ret)
+        printf("unavailable\n");
+    else
+        printf("%s\n", desc);
 
-	if (IMAGE_ENABLE_TIMESTAMP) {
-		ret = fit_get_timestamp(fit, 0, &timestamp);
-		printf("%sCreated:         ", p);
-		if (ret)
-			printf("unavailable\n");
-		else
-			genimg_print_time(timestamp);
-	}
+    if (IMAGE_ENABLE_TIMESTAMP) {
+        ret = fit_get_timestamp(fit, 0, &timestamp);
+        printf("%sCreated:         ", p);
+        if (ret)
+            printf("unavailable\n");
+        else
+            genimg_print_time(timestamp);
+    }
 
-	/* Find images parent node offset */
-	images_noffset = fdt_path_offset(fit, FIT_IMAGES_PATH);
-	if (images_noffset < 0) {
-		printf("Can't find images parent node '%s' (%s)\n",
-		       FIT_IMAGES_PATH, fdt_strerror(images_noffset));
-		return;
-	}
+    /* Find images parent node offset */
+    images_noffset = fdt_path_offset(fit, FIT_IMAGES_PATH);
+    if (images_noffset < 0) {
+        printf("Can't find images parent node '%s' (%s)\n",
+               FIT_IMAGES_PATH, fdt_strerror(images_noffset));
+        return;
+    }
 
-	/* Process its subnodes, print out component images details */
-	for (ndepth = 0, count = 0,
-		noffset = fdt_next_node(fit, images_noffset, &ndepth);
-	     (noffset >= 0) && (ndepth > 0);
-	     noffset = fdt_next_node(fit, noffset, &ndepth)) {
-		if (ndepth == 1) {
-			/*
-			 * Direct child node of the images parent node,
-			 * i.e. component image node.
-			 */
-			printf("%s Image %u (%s)\n", p, count++,
-			       fit_get_name(fit, noffset, NULL));
+    /* Process its subnodes, print out component images details */
+    for (ndepth = 0, count = 0,
+        noffset = fdt_next_node(fit, images_noffset, &ndepth);
+         (noffset >= 0) && (ndepth > 0);
+         noffset = fdt_next_node(fit, noffset, &ndepth)) {
+        if (ndepth == 1) {
+            /*
+             * Direct child node of the images parent node,
+             * i.e. component image node.
+             */
+            printf("%s Image %u (%s)\n", p, count++,
+                   fit_get_name(fit, noffset, NULL));
 
-			fit_image_print(fit, noffset, p);
-		}
-	}
+            fit_image_print(fit, noffset, p);
+        }
+    }
 
-	/* Find configurations parent node offset */
-	confs_noffset = fdt_path_offset(fit, FIT_CONFS_PATH);
-	if (confs_noffset < 0) {
-		debug("Can't get configurations parent node '%s' (%s)\n",
-		      FIT_CONFS_PATH, fdt_strerror(confs_noffset));
-		return;
-	}
+    /* Find configurations parent node offset */
+    confs_noffset = fdt_path_offset(fit, FIT_CONFS_PATH);
+    if (confs_noffset < 0) {
+        debug("Can't get configurations parent node '%s' (%s)\n",
+              FIT_CONFS_PATH, fdt_strerror(confs_noffset));
+        return;
+    }
 
-	/* get default configuration unit name from default property */
-	uname = (char *)fdt_getprop(fit, noffset, FIT_DEFAULT_PROP, NULL);
-	if (uname)
-		printf("%s Default Configuration: '%s'\n", p, uname);
+    /* get default configuration unit name from default property */
+    uname = (char *)fdt_getprop(fit, noffset, FIT_DEFAULT_PROP, NULL);
+    if (uname)
+        printf("%s Default Configuration: '%s'\n", p, uname);
 
-	/* Process its subnodes, print out configurations details */
-	for (ndepth = 0, count = 0,
-		noffset = fdt_next_node(fit, confs_noffset, &ndepth);
-	     (noffset >= 0) && (ndepth > 0);
-	     noffset = fdt_next_node(fit, noffset, &ndepth)) {
-		if (ndepth == 1) {
-			/*
-			 * Direct child node of the configurations parent node,
-			 * i.e. configuration node.
-			 */
-			printf("%s Configuration %u (%s)\n", p, count++,
-			       fit_get_name(fit, noffset, NULL));
+    /* Process its subnodes, print out configurations details */
+    for (ndepth = 0, count = 0,
+        noffset = fdt_next_node(fit, confs_noffset, &ndepth);
+         (noffset >= 0) && (ndepth > 0);
+         noffset = fdt_next_node(fit, noffset, &ndepth)) {
+        if (ndepth == 1) {
+            /*
+             * Direct child node of the configurations parent node,
+             * i.e. configuration node.
+             */
+            printf("%s Configuration %u (%s)\n", p, count++,
+                   fit_get_name(fit, noffset, NULL));
 
-			fit_conf_print(fit, noffset, p);
-		}
-	}
+            fit_conf_print(fit, noffset, p);
+        }
+    }
 }
 
 /**
@@ -259,54 +259,54 @@ void fit_print_contents(const void *fit)
  *     no returned results
  */
 static void fit_image_print_data(const void *fit, int noffset, const char *p,
-				 const char *type)
+                 const char *type)
 {
-	const char *keyname;
-	uint8_t *value;
-	int value_len;
-	char *algo;
-	int required;
-	int ret, i;
+    const char *keyname;
+    uint8_t *value;
+    int value_len;
+    char *algo;
+    int required;
+    int ret, i;
 
-	debug("%s  %s node:    '%s'\n", p, type,
-	      fit_get_name(fit, noffset, NULL));
-	printf("%s  %s algo:    ", p, type);
-	if (fit_image_hash_get_algo(fit, noffset, &algo)) {
-		printf("invalid/unsupported\n");
-		return;
-	}
-	printf("%s", algo);
-	keyname = fdt_getprop(fit, noffset, "key-name-hint", NULL);
-	required = fdt_getprop(fit, noffset, "required", NULL) != NULL;
-	if (keyname)
-		printf(":%s", keyname);
-	if (required)
-		printf(" (required)");
-	printf("\n");
+    debug("%s  %s node:    '%s'\n", p, type,
+          fit_get_name(fit, noffset, NULL));
+    printf("%s  %s algo:    ", p, type);
+    if (fit_image_hash_get_algo(fit, noffset, &algo)) {
+        printf("invalid/unsupported\n");
+        return;
+    }
+    printf("%s", algo);
+    keyname = fdt_getprop(fit, noffset, "key-name-hint", NULL);
+    required = fdt_getprop(fit, noffset, "required", NULL) != NULL;
+    if (keyname)
+        printf(":%s", keyname);
+    if (required)
+        printf(" (required)");
+    printf("\n");
 
-	ret = fit_image_hash_get_value(fit, noffset, &value,
-					&value_len);
-	printf("%s  %s value:   ", p, type);
-	if (ret) {
-		printf("unavailable\n");
-	} else {
-		for (i = 0; i < value_len; i++)
-			printf("%02x", value[i]);
-		printf("\n");
-	}
+    ret = fit_image_hash_get_value(fit, noffset, &value,
+                    &value_len);
+    printf("%s  %s value:   ", p, type);
+    if (ret) {
+        printf("unavailable\n");
+    } else {
+        for (i = 0; i < value_len; i++)
+            printf("%02x", value[i]);
+        printf("\n");
+    }
 
-	debug("%s  %s len:     %d\n", p, type, value_len);
+    debug("%s  %s len:     %d\n", p, type, value_len);
 
-	/* Signatures have a time stamp */
-	if (IMAGE_ENABLE_TIMESTAMP && keyname) {
-		time_t timestamp;
+    /* Signatures have a time stamp */
+    if (IMAGE_ENABLE_TIMESTAMP && keyname) {
+        time_t timestamp;
 
-		printf("%s  Timestamp:    ", p);
-		if (fit_get_timestamp(fit, noffset, &timestamp))
-			printf("unavailable\n");
-		else
-			genimg_print_time(timestamp);
-	}
+        printf("%s  Timestamp:    ", p);
+        if (fit_get_timestamp(fit, noffset, &timestamp))
+            printf("unavailable\n");
+        else
+            genimg_print_time(timestamp);
+    }
 }
 
 /**
@@ -321,22 +321,22 @@ static void fit_image_print_data(const void *fit, int noffset, const char *p,
  *     no returned results
  */
 static void fit_image_print_verification_data(const void *fit, int noffset,
-				       const char *p)
+                       const char *p)
 {
-	const char *name;
+    const char *name;
 
-	/*
-	 * Check subnode name, must be equal to "hash" or "signature".
-	 * Multiple hash/signature nodes require unique unit node
-	 * names, e.g. hash@1, hash@2, signature@1, signature@2, etc.
-	 */
-	name = fit_get_name(fit, noffset, NULL);
-	if (!strncmp(name, FIT_HASH_NODENAME, strlen(FIT_HASH_NODENAME))) {
-		fit_image_print_data(fit, noffset, p, "Hash");
-	} else if (!strncmp(name, FIT_SIG_NODENAME,
-				strlen(FIT_SIG_NODENAME))) {
-		fit_image_print_data(fit, noffset, p, "Sign");
-	}
+    /*
+     * Check subnode name, must be equal to "hash" or "signature".
+     * Multiple hash/signature nodes require unique unit node
+     * names, e.g. hash@1, hash@2, signature@1, signature@2, etc.
+     */
+    name = fit_get_name(fit, noffset, NULL);
+    if (!strncmp(name, FIT_HASH_NODENAME, strlen(FIT_HASH_NODENAME))) {
+        fit_image_print_data(fit, noffset, p, "Hash");
+    } else if (!strncmp(name, FIT_SIG_NODENAME,
+                strlen(FIT_SIG_NODENAME))) {
+        fit_image_print_data(fit, noffset, p, "Sign");
+    }
 }
 
 /**
@@ -356,102 +356,102 @@ static void fit_image_print_verification_data(const void *fit, int noffset,
  */
 void fit_image_print(const void *fit, int image_noffset, const char *p)
 {
-	char *desc;
-	uint8_t type, arch, os, comp;
-	size_t size;
-	ulong load, entry;
-	const void *data;
-	int noffset;
-	int ndepth;
-	int ret;
+    char *desc;
+    uint8_t type, arch, os, comp;
+    size_t size;
+    ulong load, entry;
+    const void *data;
+    int noffset;
+    int ndepth;
+    int ret;
 
-	/* Mandatory properties */
-	ret = fit_get_desc(fit, image_noffset, &desc);
-	printf("%s  Description:  ", p);
-	if (ret)
-		printf("unavailable\n");
-	else
-		printf("%s\n", desc);
+    /* Mandatory properties */
+    ret = fit_get_desc(fit, image_noffset, &desc);
+    printf("%s  Description:  ", p);
+    if (ret)
+        printf("unavailable\n");
+    else
+        printf("%s\n", desc);
 
-	if (IMAGE_ENABLE_TIMESTAMP) {
-		time_t timestamp;
+    if (IMAGE_ENABLE_TIMESTAMP) {
+        time_t timestamp;
 
-		ret = fit_get_timestamp(fit, 0, &timestamp);
-		printf("%s  Created:      ", p);
-		if (ret)
-			printf("unavailable\n");
-		else
-			genimg_print_time(timestamp);
-	}
+        ret = fit_get_timestamp(fit, 0, &timestamp);
+        printf("%s  Created:      ", p);
+        if (ret)
+            printf("unavailable\n");
+        else
+            genimg_print_time(timestamp);
+    }
 
-	fit_image_get_type(fit, image_noffset, &type);
-	printf("%s  Type:         %s\n", p, genimg_get_type_name(type));
+    fit_image_get_type(fit, image_noffset, &type);
+    printf("%s  Type:         %s\n", p, genimg_get_type_name(type));
 
-	fit_image_get_comp(fit, image_noffset, &comp);
-	printf("%s  Compression:  %s\n", p, genimg_get_comp_name(comp));
+    fit_image_get_comp(fit, image_noffset, &comp);
+    printf("%s  Compression:  %s\n", p, genimg_get_comp_name(comp));
 
-	ret = fit_image_get_data(fit, image_noffset, &data, &size);
+    ret = fit_image_get_data(fit, image_noffset, &data, &size);
 
 #ifndef USE_HOSTCC
-	printf("%s  Data Start:   ", p);
-	if (ret) {
-		printf("unavailable\n");
-	} else {
-		void *vdata = (void *)data;
+    printf("%s  Data Start:   ", p);
+    if (ret) {
+        printf("unavailable\n");
+    } else {
+        void *vdata = (void *)data;
 
-		printf("0x%08lx\n", (ulong)map_to_sysmem(vdata));
-	}
+        printf("0x%08lx\n", (ulong)map_to_sysmem(vdata));
+    }
 #endif
 
-	printf("%s  Data Size:    ", p);
-	if (ret)
-		printf("unavailable\n");
-	else
-		genimg_print_size(size);
+    printf("%s  Data Size:    ", p);
+    if (ret)
+        printf("unavailable\n");
+    else
+        genimg_print_size(size);
 
-	/* Remaining, type dependent properties */
-	if ((type == IH_TYPE_KERNEL) || (type == IH_TYPE_STANDALONE) ||
-	    (type == IH_TYPE_RAMDISK) || (type == IH_TYPE_FIRMWARE) ||
-	    (type == IH_TYPE_FLATDT)) {
-		fit_image_get_arch(fit, image_noffset, &arch);
-		printf("%s  Architecture: %s\n", p, genimg_get_arch_name(arch));
-	}
+    /* Remaining, type dependent properties */
+    if ((type == IH_TYPE_KERNEL) || (type == IH_TYPE_STANDALONE) ||
+        (type == IH_TYPE_RAMDISK) || (type == IH_TYPE_FIRMWARE) ||
+        (type == IH_TYPE_FLATDT)) {
+        fit_image_get_arch(fit, image_noffset, &arch);
+        printf("%s  Architecture: %s\n", p, genimg_get_arch_name(arch));
+    }
 
-	if ((type == IH_TYPE_KERNEL) || (type == IH_TYPE_RAMDISK)) {
-		fit_image_get_os(fit, image_noffset, &os);
-		printf("%s  OS:           %s\n", p, genimg_get_os_name(os));
-	}
+    if ((type == IH_TYPE_KERNEL) || (type == IH_TYPE_RAMDISK)) {
+        fit_image_get_os(fit, image_noffset, &os);
+        printf("%s  OS:           %s\n", p, genimg_get_os_name(os));
+    }
 
-	if ((type == IH_TYPE_KERNEL) || (type == IH_TYPE_STANDALONE) ||
-	    (type == IH_TYPE_FIRMWARE) || (type == IH_TYPE_RAMDISK) ||
-	    (type == IH_TYPE_FPGA)) {
-		ret = fit_image_get_load(fit, image_noffset, &load);
-		printf("%s  Load Address: ", p);
-		if (ret)
-			printf("unavailable\n");
-		else
-			printf("0x%08lx\n", load);
-	}
+    if ((type == IH_TYPE_KERNEL) || (type == IH_TYPE_STANDALONE) ||
+        (type == IH_TYPE_FIRMWARE) || (type == IH_TYPE_RAMDISK) ||
+        (type == IH_TYPE_FPGA)) {
+        ret = fit_image_get_load(fit, image_noffset, &load);
+        printf("%s  Load Address: ", p);
+        if (ret)
+            printf("unavailable\n");
+        else
+            printf("0x%08lx\n", load);
+    }
 
-	if ((type == IH_TYPE_KERNEL) || (type == IH_TYPE_STANDALONE) ||
-	    (type == IH_TYPE_RAMDISK)) {
-		ret = fit_image_get_entry(fit, image_noffset, &entry);
-		printf("%s  Entry Point:  ", p);
-		if (ret)
-			printf("unavailable\n");
-		else
-			printf("0x%08lx\n", entry);
-	}
+    if ((type == IH_TYPE_KERNEL) || (type == IH_TYPE_STANDALONE) ||
+        (type == IH_TYPE_RAMDISK)) {
+        ret = fit_image_get_entry(fit, image_noffset, &entry);
+        printf("%s  Entry Point:  ", p);
+        if (ret)
+            printf("unavailable\n");
+        else
+            printf("0x%08lx\n", entry);
+    }
 
-	/* Process all hash subnodes of the component image node */
-	for (ndepth = 0, noffset = fdt_next_node(fit, image_noffset, &ndepth);
-	     (noffset >= 0) && (ndepth > 0);
-	     noffset = fdt_next_node(fit, noffset, &ndepth)) {
-		if (ndepth == 1) {
-			/* Direct child node of the component image node */
-			fit_image_print_verification_data(fit, noffset, p);
-		}
-	}
+    /* Process all hash subnodes of the component image node */
+    for (ndepth = 0, noffset = fdt_next_node(fit, image_noffset, &ndepth);
+         (noffset >= 0) && (ndepth > 0);
+         noffset = fdt_next_node(fit, noffset, &ndepth)) {
+        if (ndepth == 1) {
+            /* Direct child node of the component image node */
+            fit_image_print_verification_data(fit, noffset, p);
+        }
+    }
 }
 
 #endif /* !defined(CONFIG_SPL_BUILD) || defined(CONFIG_FIT_SPL_PRINT) */
@@ -471,15 +471,15 @@ void fit_image_print(const void *fit, int image_noffset, const char *p)
  */
 int fit_get_desc(const void *fit, int noffset, char **desc)
 {
-	int len;
+    int len;
 
-	*desc = (char *)fdt_getprop(fit, noffset, FIT_DESC_PROP, &len);
-	if (*desc == NULL) {
-		fit_get_debug(fit, noffset, FIT_DESC_PROP, len);
-		return -1;
-	}
+    *desc = (char *)fdt_getprop(fit, noffset, FIT_DESC_PROP, &len);
+    if (*desc == NULL) {
+        fit_get_debug(fit, noffset, FIT_DESC_PROP, len);
+        return -1;
+    }
 
-	return 0;
+    return 0;
 }
 
 /**
@@ -499,21 +499,21 @@ int fit_get_desc(const void *fit, int noffset, char **desc)
  */
 int fit_get_timestamp(const void *fit, int noffset, time_t *timestamp)
 {
-	int len;
-	const void *data;
+    int len;
+    const void *data;
 
-	data = fdt_getprop(fit, noffset, FIT_TIMESTAMP_PROP, &len);
-	if (data == NULL) {
-		fit_get_debug(fit, noffset, FIT_TIMESTAMP_PROP, len);
-		return -1;
-	}
-	if (len != sizeof(uint32_t)) {
-		debug("FIT timestamp with incorrect size of (%u)\n", len);
-		return -2;
-	}
+    data = fdt_getprop(fit, noffset, FIT_TIMESTAMP_PROP, &len);
+    if (data == NULL) {
+        fit_get_debug(fit, noffset, FIT_TIMESTAMP_PROP, len);
+        return -1;
+    }
+    if (len != sizeof(uint32_t)) {
+        debug("FIT timestamp with incorrect size of (%u)\n", len);
+        return -2;
+    }
 
-	*timestamp = uimage_to_cpu(*((uint32_t *)data));
-	return 0;
+    *timestamp = uimage_to_cpu(*((uint32_t *)data));
+    return 0;
 }
 
 /**
@@ -531,22 +531,22 @@ int fit_get_timestamp(const void *fit, int noffset, time_t *timestamp)
  */
 int fit_image_get_node(const void *fit, const char *image_uname)
 {
-	int noffset, images_noffset;
+    int noffset, images_noffset;
 
-	images_noffset = fdt_path_offset(fit, FIT_IMAGES_PATH);
-	if (images_noffset < 0) {
-		debug("Can't find images parent node '%s' (%s)\n",
-		      FIT_IMAGES_PATH, fdt_strerror(images_noffset));
-		return images_noffset;
-	}
+    images_noffset = fdt_path_offset(fit, FIT_IMAGES_PATH);
+    if (images_noffset < 0) {
+        debug("Can't find images parent node '%s' (%s)\n",
+              FIT_IMAGES_PATH, fdt_strerror(images_noffset));
+        return images_noffset;
+    }
 
-	noffset = fdt_subnode_offset(fit, images_noffset, image_uname);
-	if (noffset < 0) {
-		debug("Can't get node offset for image unit name: '%s' (%s)\n",
-		      image_uname, fdt_strerror(noffset));
-	}
+    noffset = fdt_subnode_offset(fit, images_noffset, image_uname);
+    if (noffset < 0) {
+        debug("Can't get node offset for image unit name: '%s' (%s)\n",
+              image_uname, fdt_strerror(noffset));
+    }
 
-	return noffset;
+    return noffset;
 }
 
 /**
@@ -565,20 +565,20 @@ int fit_image_get_node(const void *fit, const char *image_uname)
  */
 int fit_image_get_os(const void *fit, int noffset, uint8_t *os)
 {
-	int len;
-	const void *data;
+    int len;
+    const void *data;
 
-	/* Get OS name from property data */
-	data = fdt_getprop(fit, noffset, FIT_OS_PROP, &len);
-	if (data == NULL) {
-		fit_get_debug(fit, noffset, FIT_OS_PROP, len);
-		*os = -1;
-		return -1;
-	}
+    /* Get OS name from property data */
+    data = fdt_getprop(fit, noffset, FIT_OS_PROP, &len);
+    if (data == NULL) {
+        fit_get_debug(fit, noffset, FIT_OS_PROP, len);
+        *os = -1;
+        return -1;
+    }
 
-	/* Translate OS name to id */
-	*os = genimg_get_os_id(data);
-	return 0;
+    /* Translate OS name to id */
+    *os = genimg_get_os_id(data);
+    return 0;
 }
 
 /**
@@ -597,20 +597,20 @@ int fit_image_get_os(const void *fit, int noffset, uint8_t *os)
  */
 int fit_image_get_arch(const void *fit, int noffset, uint8_t *arch)
 {
-	int len;
-	const void *data;
+    int len;
+    const void *data;
 
-	/* Get architecture name from property data */
-	data = fdt_getprop(fit, noffset, FIT_ARCH_PROP, &len);
-	if (data == NULL) {
-		fit_get_debug(fit, noffset, FIT_ARCH_PROP, len);
-		*arch = -1;
-		return -1;
-	}
+    /* Get architecture name from property data */
+    data = fdt_getprop(fit, noffset, FIT_ARCH_PROP, &len);
+    if (data == NULL) {
+        fit_get_debug(fit, noffset, FIT_ARCH_PROP, len);
+        *arch = -1;
+        return -1;
+    }
 
-	/* Translate architecture name to id */
-	*arch = genimg_get_arch_id(data);
-	return 0;
+    /* Translate architecture name to id */
+    *arch = genimg_get_arch_id(data);
+    return 0;
 }
 
 /**
@@ -629,20 +629,20 @@ int fit_image_get_arch(const void *fit, int noffset, uint8_t *arch)
  */
 int fit_image_get_type(const void *fit, int noffset, uint8_t *type)
 {
-	int len;
-	const void *data;
+    int len;
+    const void *data;
 
-	/* Get image type name from property data */
-	data = fdt_getprop(fit, noffset, FIT_TYPE_PROP, &len);
-	if (data == NULL) {
-		fit_get_debug(fit, noffset, FIT_TYPE_PROP, len);
-		*type = -1;
-		return -1;
-	}
+    /* Get image type name from property data */
+    data = fdt_getprop(fit, noffset, FIT_TYPE_PROP, &len);
+    if (data == NULL) {
+        fit_get_debug(fit, noffset, FIT_TYPE_PROP, len);
+        *type = -1;
+        return -1;
+    }
 
-	/* Translate image type name to id */
-	*type = genimg_get_type_id(data);
-	return 0;
+    /* Translate image type name to id */
+    *type = genimg_get_type_id(data);
+    return 0;
 }
 
 /**
@@ -661,49 +661,49 @@ int fit_image_get_type(const void *fit, int noffset, uint8_t *type)
  */
 int fit_image_get_comp(const void *fit, int noffset, uint8_t *comp)
 {
-	int len;
-	const void *data;
+    int len;
+    const void *data;
 
-	/* Get compression name from property data */
-	data = fdt_getprop(fit, noffset, FIT_COMP_PROP, &len);
-	if (data == NULL) {
-		fit_get_debug(fit, noffset, FIT_COMP_PROP, len);
-		*comp = -1;
-		return -1;
-	}
+    /* Get compression name from property data */
+    data = fdt_getprop(fit, noffset, FIT_COMP_PROP, &len);
+    if (data == NULL) {
+        fit_get_debug(fit, noffset, FIT_COMP_PROP, len);
+        *comp = -1;
+        return -1;
+    }
 
-	/* Translate compression name to id */
-	*comp = genimg_get_comp_id(data);
-	return 0;
+    /* Translate compression name to id */
+    *comp = genimg_get_comp_id(data);
+    return 0;
 }
 
 static int fit_image_get_address(const void *fit, int noffset, char *name,
-			  ulong *load)
+              ulong *load)
 {
-	int len, cell_len;
-	const fdt32_t *cell;
-	uint64_t load64 = 0;
+    int len, cell_len;
+    const fdt32_t *cell;
+    uint64_t load64 = 0;
 
-	cell = fdt_getprop(fit, noffset, name, &len);
-	if (cell == NULL) {
-		fit_get_debug(fit, noffset, name, len);
-		return -1;
-	}
+    cell = fdt_getprop(fit, noffset, name, &len);
+    if (cell == NULL) {
+        fit_get_debug(fit, noffset, name, len);
+        return -1;
+    }
 
-	if (len > sizeof(ulong)) {
-		printf("Unsupported %s address size\n", name);
-		return -1;
-	}
+    if (len > sizeof(ulong)) {
+        printf("Unsupported %s address size\n", name);
+        return -1;
+    }
 
-	cell_len = len >> 2;
-	/* Use load64 to avoid compiling warning for 32-bit target */
-	while (cell_len--) {
-		load64 = (load64 << 32) | uimage_to_cpu(*cell);
-		cell++;
-	}
-	*load = (ulong)load64;
+    cell_len = len >> 2;
+    /* Use load64 to avoid compiling warning for 32-bit target */
+    while (cell_len--) {
+        load64 = (load64 << 32) | uimage_to_cpu(*cell);
+        cell++;
+    }
+    *load = (ulong)load64;
 
-	return 0;
+    return 0;
 }
 /**
  * fit_image_get_load() - get load addr property for given component image node
@@ -720,7 +720,7 @@ static int fit_image_get_address(const void *fit, int noffset, char *name,
  */
 int fit_image_get_load(const void *fit, int noffset, ulong *load)
 {
-	return fit_image_get_address(fit, noffset, FIT_LOAD_PROP, load);
+    return fit_image_get_address(fit, noffset, FIT_LOAD_PROP, load);
 }
 
 /**
@@ -742,7 +742,7 @@ int fit_image_get_load(const void *fit, int noffset, ulong *load)
  */
 int fit_image_get_entry(const void *fit, int noffset, ulong *entry)
 {
-	return fit_image_get_address(fit, noffset, FIT_ENTRY_PROP, entry);
+    return fit_image_get_address(fit, noffset, FIT_ENTRY_PROP, entry);
 }
 
 /**
@@ -761,19 +761,67 @@ int fit_image_get_entry(const void *fit, int noffset, ulong *entry)
  *     -1, on failure
  */
 int fit_image_get_data(const void *fit, int noffset,
-		const void **data, size_t *size)
+        const void **data, size_t *size)
 {
-	int len;
+    int len;
 
-	*data = fdt_getprop(fit, noffset, FIT_DATA_PROP, &len);
-	if (*data == NULL) {
-		fit_get_debug(fit, noffset, FIT_DATA_PROP, len);
-		*size = 0;
-		return -1;
-	}
+    *data = fdt_getprop(fit, noffset, FIT_DATA_PROP, &len);
+    if (*data == NULL) {
+        fit_get_debug(fit, noffset, FIT_DATA_PROP, len);
+        *size = 0;
+        return -1;
+    }
 
-	*size = len;
-	return 0;
+    *size = len;
+    return 0;
+}
+
+/**
+ * Get 'data-offset' property from a given image node.
+ *
+ * @fit: pointer to the FIT image header
+ * @noffset: component image node offset
+ * @data_offset: holds the data-offset property
+ *
+ * returns:
+ *     0, on success
+ *     -ENOENT if the property could not be found
+ */
+int fit_image_get_data_offset(const void *fit, int noffset, int *data_offset)
+{
+    const fdt32_t *val;
+
+    val = fdt_getprop(fit, noffset, FIT_DATA_OFFSET_PROP, NULL);
+    if (!val)
+        return -ENOENT;
+
+    *data_offset = fdt32_to_cpu(*val);
+
+    return 0;
+}
+
+/**
+ * Get 'data-size' property from a given image node.
+ *
+ * @fit: pointer to the FIT image header
+ * @noffset: component image node offset
+ * @data_size: holds the data-size property
+ *
+ * returns:
+ *     0, on success
+ *     -ENOENT if the property could not be found
+ */
+int fit_image_get_data_size(const void *fit, int noffset, int *data_size)
+{
+    const fdt32_t *val;
+
+    val = fdt_getprop(fit, noffset, FIT_DATA_SIZE_PROP, NULL);
+    if (!val)
+        return -ENOENT;
+
+    *data_size = fdt32_to_cpu(*val);
+
+    return 0;
 }
 
 /**
@@ -791,15 +839,15 @@ int fit_image_get_data(const void *fit, int noffset,
  */
 int fit_image_hash_get_algo(const void *fit, int noffset, char **algo)
 {
-	int len;
+    int len;
 
-	*algo = (char *)fdt_getprop(fit, noffset, FIT_ALGO_PROP, &len);
-	if (*algo == NULL) {
-		fit_get_debug(fit, noffset, FIT_ALGO_PROP, len);
-		return -1;
-	}
+    *algo = (char *)fdt_getprop(fit, noffset, FIT_ALGO_PROP, &len);
+    if (*algo == NULL) {
+        fit_get_debug(fit, noffset, FIT_ALGO_PROP, len);
+        return -1;
+    }
 
-	return 0;
+    return 0;
 }
 
 /**
@@ -818,19 +866,19 @@ int fit_image_hash_get_algo(const void *fit, int noffset, char **algo)
  *     -1, on failure
  */
 int fit_image_hash_get_value(const void *fit, int noffset, uint8_t **value,
-				int *value_len)
+                int *value_len)
 {
-	int len;
+    int len;
 
-	*value = (uint8_t *)fdt_getprop(fit, noffset, FIT_VALUE_PROP, &len);
-	if (*value == NULL) {
-		fit_get_debug(fit, noffset, FIT_VALUE_PROP, len);
-		*value_len = 0;
-		return -1;
-	}
+    *value = (uint8_t *)fdt_getprop(fit, noffset, FIT_VALUE_PROP, &len);
+    if (*value == NULL) {
+        fit_get_debug(fit, noffset, FIT_VALUE_PROP, len);
+        *value_len = 0;
+        return -1;
+    }
 
-	*value_len = len;
-	return 0;
+    *value_len = len;
+    return 0;
 }
 
 /**
@@ -849,21 +897,21 @@ int fit_image_hash_get_value(const void *fit, int noffset, uint8_t **value,
  */
 static int fit_image_hash_get_ignore(const void *fit, int noffset, int *ignore)
 {
-	int len;
-	int *value;
+    int len;
+    int *value;
 
-	value = (int *)fdt_getprop(fit, noffset, FIT_IGNORE_PROP, &len);
-	if (value == NULL || len != sizeof(int))
-		*ignore = 0;
-	else
-		*ignore = *value;
+    value = (int *)fdt_getprop(fit, noffset, FIT_IGNORE_PROP, &len);
+    if (value == NULL || len != sizeof(int))
+        *ignore = 0;
+    else
+        *ignore = *value;
 
-	return 0;
+    return 0;
 }
 
 ulong fit_get_end(const void *fit)
 {
-	return map_to_sysmem((void *)(fit + fdt_totalsize(fit)));
+    return map_to_sysmem((void *)(fit + fdt_totalsize(fit)));
 }
 
 /**
@@ -881,20 +929,20 @@ ulong fit_get_end(const void *fit)
  */
 int fit_set_timestamp(void *fit, int noffset, time_t timestamp)
 {
-	uint32_t t;
-	int ret;
+    uint32_t t;
+    int ret;
 
-	t = cpu_to_uimage(timestamp);
-	ret = fdt_setprop(fit, noffset, FIT_TIMESTAMP_PROP, &t,
-				sizeof(uint32_t));
-	if (ret) {
-		debug("Can't set '%s' property for '%s' node (%s)\n",
-		      FIT_TIMESTAMP_PROP, fit_get_name(fit, noffset, NULL),
-		      fdt_strerror(ret));
-		return ret == -FDT_ERR_NOSPACE ? -ENOSPC : -1;
-	}
+    t = cpu_to_uimage(timestamp);
+    ret = fdt_setprop(fit, noffset, FIT_TIMESTAMP_PROP, &t,
+                sizeof(uint32_t));
+    if (ret) {
+        debug("Can't set '%s' property for '%s' node (%s)\n",
+              FIT_TIMESTAMP_PROP, fit_get_name(fit, noffset, NULL),
+              fdt_strerror(ret));
+        return ret == -FDT_ERR_NOSPACE ? -ENOSPC : -1;
+    }
 
-	return 0;
+    return 0;
 }
 
 /**
@@ -916,77 +964,77 @@ int fit_set_timestamp(void *fit, int noffset, time_t timestamp)
  *    -1, when algo is unsupported
  */
 int calculate_hash(const void *data, int data_len, const char *algo,
-			uint8_t *value, int *value_len)
+            uint8_t *value, int *value_len)
 {
-	if (IMAGE_ENABLE_CRC32 && strcmp(algo, "crc32") == 0) {
-		*((uint32_t *)value) = crc32_wd(0, data, data_len,
-							CHUNKSZ_CRC32);
-		*((uint32_t *)value) = cpu_to_uimage(*((uint32_t *)value));
-		*value_len = 4;
-	} else if (IMAGE_ENABLE_SHA1 && strcmp(algo, "sha1") == 0) {
-		sha1_csum_wd((unsigned char *)data, data_len,
-			     (unsigned char *)value, CHUNKSZ_SHA1);
-		*value_len = 20;
-	} else if (IMAGE_ENABLE_SHA256 && strcmp(algo, "sha256") == 0) {
-		sha256_csum_wd((unsigned char *)data, data_len,
-			       (unsigned char *)value, CHUNKSZ_SHA256);
-		*value_len = SHA256_SUM_LEN;
-	} else if (IMAGE_ENABLE_MD5 && strcmp(algo, "md5") == 0) {
-		md5_wd((unsigned char *)data, data_len, value, CHUNKSZ_MD5);
-		*value_len = 16;
-	} else {
-		debug("Unsupported hash alogrithm\n");
-		return -1;
-	}
-	return 0;
+    if (IMAGE_ENABLE_CRC32 && strcmp(algo, "crc32") == 0) {
+        *((uint32_t *)value) = crc32_wd(0, data, data_len,
+                            CHUNKSZ_CRC32);
+        *((uint32_t *)value) = cpu_to_uimage(*((uint32_t *)value));
+        *value_len = 4;
+    } else if (IMAGE_ENABLE_SHA1 && strcmp(algo, "sha1") == 0) {
+        sha1_csum_wd((unsigned char *)data, data_len,
+                 (unsigned char *)value, CHUNKSZ_SHA1);
+        *value_len = 20;
+    } else if (IMAGE_ENABLE_SHA256 && strcmp(algo, "sha256") == 0) {
+        sha256_csum_wd((unsigned char *)data, data_len,
+                   (unsigned char *)value, CHUNKSZ_SHA256);
+        *value_len = SHA256_SUM_LEN;
+    } else if (IMAGE_ENABLE_MD5 && strcmp(algo, "md5") == 0) {
+        md5_wd((unsigned char *)data, data_len, value, CHUNKSZ_MD5);
+        *value_len = 16;
+    } else {
+        debug("Unsupported hash alogrithm\n");
+        return -1;
+    }
+    return 0;
 }
 
 static int fit_image_check_hash(const void *fit, int noffset, const void *data,
-				size_t size, char **err_msgp)
+                size_t size, char **err_msgp)
 {
-	uint8_t value[FIT_MAX_HASH_LEN];
-	int value_len;
-	char *algo;
-	uint8_t *fit_value;
-	int fit_value_len;
-	int ignore;
+    uint8_t value[FIT_MAX_HASH_LEN];
+    int value_len;
+    char *algo;
+    uint8_t *fit_value;
+    int fit_value_len;
+    int ignore;
 
-	*err_msgp = NULL;
+    *err_msgp = NULL;
 
-	if (fit_image_hash_get_algo(fit, noffset, &algo)) {
-		*err_msgp = "Can't get hash algo property";
-		return -1;
-	}
-	printf("%s", algo);
+    if (fit_image_hash_get_algo(fit, noffset, &algo)) {
+        *err_msgp = "Can't get hash algo property";
+        return -1;
+    }
+    printf("%s", algo);
 
-	if (IMAGE_ENABLE_IGNORE) {
-		fit_image_hash_get_ignore(fit, noffset, &ignore);
-		if (ignore) {
-			printf("-skipped ");
-			return 0;
-		}
-	}
+    if (IMAGE_ENABLE_IGNORE) {
+        fit_image_hash_get_ignore(fit, noffset, &ignore);
+        if (ignore) {
+            printf("-skipped ");
+            return 0;
+        }
+    }
 
-	if (fit_image_hash_get_value(fit, noffset, &fit_value,
-				     &fit_value_len)) {
-		*err_msgp = "Can't get hash value property";
-		return -1;
-	}
+    if (fit_image_hash_get_value(fit, noffset, &fit_value,
+                     &fit_value_len)) {
+        *err_msgp = "Can't get hash value property";
+        return -1;
+    }
 
-	if (calculate_hash(data, size, algo, value, &value_len)) {
-		*err_msgp = "Unsupported hash algorithm";
-		return -1;
-	}
+    if (calculate_hash(data, size, algo, value, &value_len)) {
+        *err_msgp = "Unsupported hash algorithm";
+        return -1;
+    }
 
-	if (value_len != fit_value_len) {
-		*err_msgp = "Bad hash value len";
-		return -1;
-	} else if (memcmp(value, fit_value, value_len) != 0) {
-		*err_msgp = "Bad hash value";
-		return -1;
-	}
+    if (value_len != fit_value_len) {
+        *err_msgp = "Bad hash value len";
+        return -1;
+    } else if (memcmp(value, fit_value, value_len) != 0) {
+        *err_msgp = "Bad hash value";
+        return -1;
+    }
 
-	return 0;
+    return 0;
 }
 
 /**
@@ -1004,73 +1052,73 @@ static int fit_image_check_hash(const void *fit, int noffset, const void *data,
  */
 int fit_image_verify(const void *fit, int image_noffset)
 {
-	const void	*data;
-	size_t		size;
-	int		noffset = 0;
-	char		*err_msg = "";
-	int verify_all = 1;
-	int ret;
+    const void  *data;
+    size_t      size;
+    int     noffset = 0;
+    char        *err_msg = "";
+    int verify_all = 1;
+    int ret;
 
-	/* Get image data and data length */
-	if (fit_image_get_data(fit, image_noffset, &data, &size)) {
-		err_msg = "Can't get image data/size";
-		goto error;
-	}
+    /* Get image data and data length */
+    if (fit_image_get_data(fit, image_noffset, &data, &size)) {
+        err_msg = "Can't get image data/size";
+        goto error;
+    }
 
-	/* Verify all required signatures */
-	if (IMAGE_ENABLE_VERIFY &&
-	    fit_image_verify_required_sigs(fit, image_noffset, data, size,
-					   gd_fdt_blob(), &verify_all)) {
-		err_msg = "Unable to verify required signature";
-		goto error;
-	}
+    /* Verify all required signatures */
+    if (IMAGE_ENABLE_VERIFY &&
+        fit_image_verify_required_sigs(fit, image_noffset, data, size,
+                       gd_fdt_blob(), &verify_all)) {
+        err_msg = "Unable to verify required signature";
+        goto error;
+    }
 
-	/* Process all hash subnodes of the component image node */
-	fdt_for_each_subnode(fit, noffset, image_noffset) {
-		const char *name = fit_get_name(fit, noffset, NULL);
+    /* Process all hash subnodes of the component image node */
+    fdt_for_each_subnode(fit, noffset, image_noffset) {
+        const char *name = fit_get_name(fit, noffset, NULL);
 
-		/*
-		 * Check subnode name, must be equal to "hash".
-		 * Multiple hash nodes require unique unit node
-		 * names, e.g. hash@1, hash@2, etc.
-		 */
-		if (!strncmp(name, FIT_HASH_NODENAME,
-			     strlen(FIT_HASH_NODENAME))) {
-			if (fit_image_check_hash(fit, noffset, data, size,
-						 &err_msg))
-				goto error;
-			puts("+ ");
-		} else if (IMAGE_ENABLE_VERIFY && verify_all &&
-				!strncmp(name, FIT_SIG_NODENAME,
-					strlen(FIT_SIG_NODENAME))) {
-			ret = fit_image_check_sig(fit, noffset, data,
-							size, -1, &err_msg);
+        /*
+         * Check subnode name, must be equal to "hash".
+         * Multiple hash nodes require unique unit node
+         * names, e.g. hash@1, hash@2, etc.
+         */
+        if (!strncmp(name, FIT_HASH_NODENAME,
+                 strlen(FIT_HASH_NODENAME))) {
+            if (fit_image_check_hash(fit, noffset, data, size,
+                         &err_msg))
+                goto error;
+            puts("+ ");
+        } else if (IMAGE_ENABLE_VERIFY && verify_all &&
+                !strncmp(name, FIT_SIG_NODENAME,
+                    strlen(FIT_SIG_NODENAME))) {
+            ret = fit_image_check_sig(fit, noffset, data,
+                            size, -1, &err_msg);
 
-			/*
-			 * Show an indication on failure, but do not return
-			 * an error. Only keys marked 'required' can cause
-			 * an image validation failure. See the call to
-			 * fit_image_verify_required_sigs() above.
-			 */
-			if (ret)
-				puts("- ");
-			else
-				puts("+ ");
-		}
-	}
+            /*
+             * Show an indication on failure, but do not return
+             * an error. Only keys marked 'required' can cause
+             * an image validation failure. See the call to
+             * fit_image_verify_required_sigs() above.
+             */
+            if (ret)
+                puts("- ");
+            else
+                puts("+ ");
+        }
+    }
 
-	if (noffset == -FDT_ERR_TRUNCATED || noffset == -FDT_ERR_BADSTRUCTURE) {
-		err_msg = "Corrupted or truncated tree";
-		goto error;
-	}
+    if (noffset == -FDT_ERR_TRUNCATED || noffset == -FDT_ERR_BADSTRUCTURE) {
+        err_msg = "Corrupted or truncated tree";
+        goto error;
+    }
 
-	return 1;
+    return 1;
 
 error:
-	printf(" error!\n%s for '%s' hash node in '%s' image node\n",
-	       err_msg, fit_get_name(fit, noffset, NULL),
-	       fit_get_name(fit, image_noffset, NULL));
-	return 0;
+    printf(" error!\n%s for '%s' hash node in '%s' image node\n",
+           err_msg, fit_get_name(fit, noffset, NULL),
+           fit_get_name(fit, image_noffset, NULL));
+    return 0;
 }
 
 /**
@@ -1086,41 +1134,41 @@ error:
  */
 int fit_all_image_verify(const void *fit)
 {
-	int images_noffset;
-	int noffset;
-	int ndepth;
-	int count;
+    int images_noffset;
+    int noffset;
+    int ndepth;
+    int count;
 
-	/* Find images parent node offset */
-	images_noffset = fdt_path_offset(fit, FIT_IMAGES_PATH);
-	if (images_noffset < 0) {
-		printf("Can't find images parent node '%s' (%s)\n",
-		       FIT_IMAGES_PATH, fdt_strerror(images_noffset));
-		return 0;
-	}
+    /* Find images parent node offset */
+    images_noffset = fdt_path_offset(fit, FIT_IMAGES_PATH);
+    if (images_noffset < 0) {
+        printf("Can't find images parent node '%s' (%s)\n",
+               FIT_IMAGES_PATH, fdt_strerror(images_noffset));
+        return 0;
+    }
 
-	/* Process all image subnodes, check hashes for each */
-	printf("## Checking hash(es) for FIT Image at %08lx ...\n",
-	       (ulong)fit);
-	for (ndepth = 0, count = 0,
-	     noffset = fdt_next_node(fit, images_noffset, &ndepth);
-			(noffset >= 0) && (ndepth > 0);
-			noffset = fdt_next_node(fit, noffset, &ndepth)) {
-		if (ndepth == 1) {
-			/*
-			 * Direct child node of the images parent node,
-			 * i.e. component image node.
-			 */
-			printf("   Hash(es) for Image %u (%s): ", count,
-			       fit_get_name(fit, noffset, NULL));
-			count++;
+    /* Process all image subnodes, check hashes for each */
+    printf("## Checking hash(es) for FIT Image at %08lx ...\n",
+           (ulong)fit);
+    for (ndepth = 0, count = 0,
+         noffset = fdt_next_node(fit, images_noffset, &ndepth);
+            (noffset >= 0) && (ndepth > 0);
+            noffset = fdt_next_node(fit, noffset, &ndepth)) {
+        if (ndepth == 1) {
+            /*
+             * Direct child node of the images parent node,
+             * i.e. component image node.
+             */
+            printf("   Hash(es) for Image %u (%s): ", count,
+                   fit_get_name(fit, noffset, NULL));
+            count++;
 
-			if (!fit_image_verify(fit, noffset))
-				return 0;
-			printf("\n");
-		}
-	}
-	return 1;
+            if (!fit_image_verify(fit, noffset))
+                return 0;
+            printf("\n");
+        }
+    }
+    return 1;
 }
 
 /**
@@ -1138,11 +1186,11 @@ int fit_all_image_verify(const void *fit)
  */
 int fit_image_check_os(const void *fit, int noffset, uint8_t os)
 {
-	uint8_t image_os;
+    uint8_t image_os;
 
-	if (fit_image_get_os(fit, noffset, &image_os))
-		return 0;
-	return (os == image_os);
+    if (fit_image_get_os(fit, noffset, &image_os))
+        return 0;
+    return (os == image_os);
 }
 
 /**
@@ -1160,12 +1208,12 @@ int fit_image_check_os(const void *fit, int noffset, uint8_t os)
  */
 int fit_image_check_arch(const void *fit, int noffset, uint8_t arch)
 {
-	uint8_t image_arch;
+    uint8_t image_arch;
 
-	if (fit_image_get_arch(fit, noffset, &image_arch))
-		return 0;
-	return (arch == image_arch) ||
-		(arch == IH_ARCH_I386 && image_arch == IH_ARCH_X86_64);
+    if (fit_image_get_arch(fit, noffset, &image_arch))
+        return 0;
+    return (arch == image_arch) ||
+        (arch == IH_ARCH_I386 && image_arch == IH_ARCH_X86_64);
 }
 
 /**
@@ -1183,11 +1231,11 @@ int fit_image_check_arch(const void *fit, int noffset, uint8_t arch)
  */
 int fit_image_check_type(const void *fit, int noffset, uint8_t type)
 {
-	uint8_t image_type;
+    uint8_t image_type;
 
-	if (fit_image_get_type(fit, noffset, &image_type))
-		return 0;
-	return (type == image_type);
+    if (fit_image_get_type(fit, noffset, &image_type))
+        return 0;
+    return (type == image_type);
 }
 
 /**
@@ -1206,11 +1254,11 @@ int fit_image_check_type(const void *fit, int noffset, uint8_t type)
  */
 int fit_image_check_comp(const void *fit, int noffset, uint8_t comp)
 {
-	uint8_t image_comp;
+    uint8_t image_comp;
 
-	if (fit_image_get_comp(fit, noffset, &image_comp))
-		return 0;
-	return (comp == image_comp);
+    if (fit_image_get_comp(fit, noffset, &image_comp))
+        return 0;
+    return (comp == image_comp);
 }
 
 /**
@@ -1226,27 +1274,27 @@ int fit_image_check_comp(const void *fit, int noffset, uint8_t comp)
  */
 int fit_check_format(const void *fit)
 {
-	/* mandatory / node 'description' property */
-	if (fdt_getprop(fit, 0, FIT_DESC_PROP, NULL) == NULL) {
-		debug("Wrong FIT format: no description\n");
-		return 0;
-	}
+    /* mandatory / node 'description' property */
+    if (fdt_getprop(fit, 0, FIT_DESC_PROP, NULL) == NULL) {
+        debug("Wrong FIT format: no description\n");
+        return 0;
+    }
 
-	if (IMAGE_ENABLE_TIMESTAMP) {
-		/* mandatory / node 'timestamp' property */
-		if (fdt_getprop(fit, 0, FIT_TIMESTAMP_PROP, NULL) == NULL) {
-			debug("Wrong FIT format: no timestamp\n");
-			return 0;
-		}
-	}
+    if (IMAGE_ENABLE_TIMESTAMP) {
+        /* mandatory / node 'timestamp' property */
+        if (fdt_getprop(fit, 0, FIT_TIMESTAMP_PROP, NULL) == NULL) {
+            debug("Wrong FIT format: no timestamp\n");
+            return 0;
+        }
+    }
 
-	/* mandatory subimages parent '/images' node */
-	if (fdt_path_offset(fit, FIT_IMAGES_PATH) < 0) {
-		debug("Wrong FIT format: no images parent node\n");
-		return 0;
-	}
+    /* mandatory subimages parent '/images' node */
+    if (fdt_path_offset(fit, FIT_IMAGES_PATH) < 0) {
+        debug("Wrong FIT format: no images parent node\n");
+        return 0;
+    }
 
-	return 1;
+    return 1;
 }
 
 
@@ -1291,89 +1339,89 @@ int fit_check_format(const void *fit)
  */
 int fit_conf_find_compat(const void *fit, const void *fdt)
 {
-	int ndepth = 0;
-	int noffset, confs_noffset, images_noffset;
-	const void *fdt_compat;
-	int fdt_compat_len;
-	int best_match_offset = 0;
-	int best_match_pos = 0;
+    int ndepth = 0;
+    int noffset, confs_noffset, images_noffset;
+    const void *fdt_compat;
+    int fdt_compat_len;
+    int best_match_offset = 0;
+    int best_match_pos = 0;
 
-	confs_noffset = fdt_path_offset(fit, FIT_CONFS_PATH);
-	images_noffset = fdt_path_offset(fit, FIT_IMAGES_PATH);
-	if (confs_noffset < 0 || images_noffset < 0) {
-		debug("Can't find configurations or images nodes.\n");
-		return -1;
-	}
+    confs_noffset = fdt_path_offset(fit, FIT_CONFS_PATH);
+    images_noffset = fdt_path_offset(fit, FIT_IMAGES_PATH);
+    if (confs_noffset < 0 || images_noffset < 0) {
+        debug("Can't find configurations or images nodes.\n");
+        return -1;
+    }
 
-	fdt_compat = fdt_getprop(fdt, 0, "compatible", &fdt_compat_len);
-	if (!fdt_compat) {
-		debug("Fdt for comparison has no \"compatible\" property.\n");
-		return -1;
-	}
+    fdt_compat = fdt_getprop(fdt, 0, "compatible", &fdt_compat_len);
+    if (!fdt_compat) {
+        debug("Fdt for comparison has no \"compatible\" property.\n");
+        return -1;
+    }
 
-	/*
-	 * Loop over the configurations in the FIT image.
-	 */
-	for (noffset = fdt_next_node(fit, confs_noffset, &ndepth);
-			(noffset >= 0) && (ndepth > 0);
-			noffset = fdt_next_node(fit, noffset, &ndepth)) {
-		const void *kfdt;
-		const char *kfdt_name;
-		int kfdt_noffset;
-		const char *cur_fdt_compat;
-		int len;
-		size_t size;
-		int i;
+    /*
+     * Loop over the configurations in the FIT image.
+     */
+    for (noffset = fdt_next_node(fit, confs_noffset, &ndepth);
+            (noffset >= 0) && (ndepth > 0);
+            noffset = fdt_next_node(fit, noffset, &ndepth)) {
+        const void *kfdt;
+        const char *kfdt_name;
+        int kfdt_noffset;
+        const char *cur_fdt_compat;
+        int len;
+        size_t size;
+        int i;
 
-		if (ndepth > 1)
-			continue;
+        if (ndepth > 1)
+            continue;
 
-		kfdt_name = fdt_getprop(fit, noffset, "fdt", &len);
-		if (!kfdt_name) {
-			debug("No fdt property found.\n");
-			continue;
-		}
-		kfdt_noffset = fdt_subnode_offset(fit, images_noffset,
-						  kfdt_name);
-		if (kfdt_noffset < 0) {
-			debug("No image node named \"%s\" found.\n",
-			      kfdt_name);
-			continue;
-		}
-		/*
-		 * Get a pointer to this configuration's fdt.
-		 */
-		if (fit_image_get_data(fit, kfdt_noffset, &kfdt, &size)) {
-			debug("Failed to get fdt \"%s\".\n", kfdt_name);
-			continue;
-		}
+        kfdt_name = fdt_getprop(fit, noffset, "fdt", &len);
+        if (!kfdt_name) {
+            debug("No fdt property found.\n");
+            continue;
+        }
+        kfdt_noffset = fdt_subnode_offset(fit, images_noffset,
+                          kfdt_name);
+        if (kfdt_noffset < 0) {
+            debug("No image node named \"%s\" found.\n",
+                  kfdt_name);
+            continue;
+        }
+        /*
+         * Get a pointer to this configuration's fdt.
+         */
+        if (fit_image_get_data(fit, kfdt_noffset, &kfdt, &size)) {
+            debug("Failed to get fdt \"%s\".\n", kfdt_name);
+            continue;
+        }
 
-		len = fdt_compat_len;
-		cur_fdt_compat = fdt_compat;
-		/*
-		 * Look for a match for each U-Boot compatibility string in
-		 * turn in this configuration's fdt.
-		 */
-		for (i = 0; len > 0 &&
-		     (!best_match_offset || best_match_pos > i); i++) {
-			int cur_len = strlen(cur_fdt_compat) + 1;
+        len = fdt_compat_len;
+        cur_fdt_compat = fdt_compat;
+        /*
+         * Look for a match for each U-Boot compatibility string in
+         * turn in this configuration's fdt.
+         */
+        for (i = 0; len > 0 &&
+             (!best_match_offset || best_match_pos > i); i++) {
+            int cur_len = strlen(cur_fdt_compat) + 1;
 
-			if (!fdt_node_check_compatible(kfdt, 0,
-						       cur_fdt_compat)) {
-				best_match_offset = noffset;
-				best_match_pos = i;
-				break;
-			}
-			len -= cur_len;
-			cur_fdt_compat += cur_len;
-		}
-	}
-	if (!best_match_offset) {
-		debug("No match found.\n");
-		return -1;
-	}
+            if (!fdt_node_check_compatible(kfdt, 0,
+                               cur_fdt_compat)) {
+                best_match_offset = noffset;
+                best_match_pos = i;
+                break;
+            }
+            len -= cur_len;
+            cur_fdt_compat += cur_len;
+        }
+    }
+    if (!best_match_offset) {
+        debug("No match found.\n");
+        return -1;
+    }
 
-	return best_match_offset;
+    return best_match_offset;
 }
 
 /**
@@ -1396,50 +1444,50 @@ int fit_conf_find_compat(const void *fit, const void *fdt)
  */
 int fit_conf_get_node(const void *fit, const char *conf_uname)
 {
-	int noffset, confs_noffset;
-	int len;
+    int noffset, confs_noffset;
+    int len;
 
-	confs_noffset = fdt_path_offset(fit, FIT_CONFS_PATH);
-	if (confs_noffset < 0) {
-		debug("Can't find configurations parent node '%s' (%s)\n",
-		      FIT_CONFS_PATH, fdt_strerror(confs_noffset));
-		return confs_noffset;
-	}
+    confs_noffset = fdt_path_offset(fit, FIT_CONFS_PATH);
+    if (confs_noffset < 0) {
+        debug("Can't find configurations parent node '%s' (%s)\n",
+              FIT_CONFS_PATH, fdt_strerror(confs_noffset));
+        return confs_noffset;
+    }
 
-	if (conf_uname == NULL) {
-		/* get configuration unit name from the default property */
-		debug("No configuration specified, trying default...\n");
-		conf_uname = (char *)fdt_getprop(fit, confs_noffset,
-						 FIT_DEFAULT_PROP, &len);
-		if (conf_uname == NULL) {
-			fit_get_debug(fit, confs_noffset, FIT_DEFAULT_PROP,
-				      len);
-			return len;
-		}
-		debug("Found default configuration: '%s'\n", conf_uname);
-	}
+    if (conf_uname == NULL) {
+        /* get configuration unit name from the default property */
+        debug("No configuration specified, trying default...\n");
+        conf_uname = (char *)fdt_getprop(fit, confs_noffset,
+                         FIT_DEFAULT_PROP, &len);
+        if (conf_uname == NULL) {
+            fit_get_debug(fit, confs_noffset, FIT_DEFAULT_PROP,
+                      len);
+            return len;
+        }
+        debug("Found default configuration: '%s'\n", conf_uname);
+    }
 
-	noffset = fdt_subnode_offset(fit, confs_noffset, conf_uname);
-	if (noffset < 0) {
-		debug("Can't get node offset for configuration unit name: '%s' (%s)\n",
-		      conf_uname, fdt_strerror(noffset));
-	}
+    noffset = fdt_subnode_offset(fit, confs_noffset, conf_uname);
+    if (noffset < 0) {
+        debug("Can't get node offset for configuration unit name: '%s' (%s)\n",
+              conf_uname, fdt_strerror(noffset));
+    }
 
-	return noffset;
+    return noffset;
 }
 
 int fit_conf_get_prop_node(const void *fit, int noffset,
-		const char *prop_name)
+        const char *prop_name)
 {
-	char *uname;
-	int len;
+    char *uname;
+    int len;
 
-	/* get kernel image unit name from configuration kernel property */
-	uname = (char *)fdt_getprop(fit, noffset, prop_name, &len);
-	if (uname == NULL)
-		return len;
+    /* get kernel image unit name from configuration kernel property */
+    uname = (char *)fdt_getprop(fit, noffset, prop_name, &len);
+    if (uname == NULL)
+        return len;
 
-	return fit_image_get_node(fit, uname);
+    return fit_image_get_node(fit, uname);
 }
 
 /**
@@ -1456,120 +1504,120 @@ int fit_conf_get_prop_node(const void *fit, int noffset,
  */
 void fit_conf_print(const void *fit, int noffset, const char *p)
 {
-	char *desc;
-	char *uname;
-	int ret;
-	int loadables_index;
+    char *desc;
+    char *uname;
+    int ret;
+    int loadables_index;
 
-	/* Mandatory properties */
-	ret = fit_get_desc(fit, noffset, &desc);
-	printf("%s  Description:  ", p);
-	if (ret)
-		printf("unavailable\n");
-	else
-		printf("%s\n", desc);
+    /* Mandatory properties */
+    ret = fit_get_desc(fit, noffset, &desc);
+    printf("%s  Description:  ", p);
+    if (ret)
+        printf("unavailable\n");
+    else
+        printf("%s\n", desc);
 
-	uname = (char *)fdt_getprop(fit, noffset, FIT_KERNEL_PROP, NULL);
-	printf("%s  Kernel:       ", p);
-	if (uname == NULL)
-		printf("unavailable\n");
-	else
-		printf("%s\n", uname);
+    uname = (char *)fdt_getprop(fit, noffset, FIT_KERNEL_PROP, NULL);
+    printf("%s  Kernel:       ", p);
+    if (uname == NULL)
+        printf("unavailable\n");
+    else
+        printf("%s\n", uname);
 
-	/* Optional properties */
-	uname = (char *)fdt_getprop(fit, noffset, FIT_RAMDISK_PROP, NULL);
-	if (uname)
-		printf("%s  Init Ramdisk: %s\n", p, uname);
+    /* Optional properties */
+    uname = (char *)fdt_getprop(fit, noffset, FIT_RAMDISK_PROP, NULL);
+    if (uname)
+        printf("%s  Init Ramdisk: %s\n", p, uname);
 
-	uname = (char *)fdt_getprop(fit, noffset, FIT_FDT_PROP, NULL);
-	if (uname)
-		printf("%s  FDT:          %s\n", p, uname);
+    uname = (char *)fdt_getprop(fit, noffset, FIT_FDT_PROP, NULL);
+    if (uname)
+        printf("%s  FDT:          %s\n", p, uname);
 
-	uname = (char *)fdt_getprop(fit, noffset, FIT_FPGA_PROP, NULL);
-	if (uname)
-		printf("%s  FPGA:         %s\n", p, uname);
+    uname = (char *)fdt_getprop(fit, noffset, FIT_FPGA_PROP, NULL);
+    if (uname)
+        printf("%s  FPGA:         %s\n", p, uname);
 
-	/* Print out all of the specified loadables */
-	for (loadables_index = 0;
-	     fdt_get_string_index(fit, noffset,
-			FIT_LOADABLE_PROP,
-			loadables_index,
-			(const char **)&uname) == 0;
-	     loadables_index++)
-	{
-		if (loadables_index == 0) {
-			printf("%s  Loadables:    ", p);
-		} else {
-			printf("%s                ", p);
-		}
-		printf("%s\n", uname);
-	}
+    /* Print out all of the specified loadables */
+    for (loadables_index = 0;
+         fdt_get_string_index(fit, noffset,
+            FIT_LOADABLE_PROP,
+            loadables_index,
+            (const char **)&uname) == 0;
+         loadables_index++)
+    {
+        if (loadables_index == 0) {
+            printf("%s  Loadables:    ", p);
+        } else {
+            printf("%s                ", p);
+        }
+        printf("%s\n", uname);
+    }
 }
 
 static int fit_image_select(const void *fit, int rd_noffset, int verify)
 {
 #if !defined(USE_HOSTCC) && defined(CONFIG_FIT_IMAGE_POST_PROCESS)
-	const void *data;
-	size_t size;
-	int ret;
+    const void *data;
+    size_t size;
+    int ret;
 #endif
 
-	fit_image_print(fit, rd_noffset, "   ");
+    fit_image_print(fit, rd_noffset, "   ");
 
-	if (verify) {
-		puts("   Verifying Hash Integrity ... ");
-		if (!fit_image_verify(fit, rd_noffset)) {
-			puts("Bad Data Hash\n");
-			return -EACCES;
-		}
-		puts("OK\n");
-	}
+    if (verify) {
+        puts("   Verifying Hash Integrity ... ");
+        if (!fit_image_verify(fit, rd_noffset)) {
+            puts("Bad Data Hash\n");
+            return -EACCES;
+        }
+        puts("OK\n");
+    }
 
 #if !defined(USE_HOSTCC) && defined(CONFIG_FIT_IMAGE_POST_PROCESS)
-	ret = fit_image_get_data(fit, rd_noffset, &data, &size);
-	if (ret)
-		return ret;
+    ret = fit_image_get_data(fit, rd_noffset, &data, &size);
+    if (ret)
+        return ret;
 
-	/* perform any post-processing on the image data */
-	board_fit_image_post_process((void **)&data, &size);
+    /* perform any post-processing on the image data */
+    board_fit_image_post_process((void **)&data, &size);
 
-	/*
-	 * update U-Boot's understanding of the "data" property start address
-	 * and size according to the performed post-processing
-	 */
-	ret = fdt_setprop((void *)fit, rd_noffset, FIT_DATA_PROP, data, size);
-	if (ret)
-		return ret;
+    /*
+     * update U-Boot's understanding of the "data" property start address
+     * and size according to the performed post-processing
+     */
+    ret = fdt_setprop((void *)fit, rd_noffset, FIT_DATA_PROP, data, size);
+    if (ret)
+        return ret;
 #endif
 
-	return 0;
+    return 0;
 }
 
 int fit_get_node_from_config(bootm_headers_t *images, const char *prop_name,
-			ulong addr)
+            ulong addr)
 {
-	int cfg_noffset;
-	void *fit_hdr;
-	int noffset;
+    int cfg_noffset;
+    void *fit_hdr;
+    int noffset;
 
-	debug("*  %s: using config '%s' from image at 0x%08lx\n",
-	      prop_name, images->fit_uname_cfg, addr);
+    debug("*  %s: using config '%s' from image at 0x%08lx\n",
+          prop_name, images->fit_uname_cfg, addr);
 
-	/* Check whether configuration has this property defined */
-	fit_hdr = map_sysmem(addr, 0);
-	cfg_noffset = fit_conf_get_node(fit_hdr, images->fit_uname_cfg);
-	if (cfg_noffset < 0) {
-		debug("*  %s: no such config\n", prop_name);
-		return -EINVAL;
-	}
+    /* Check whether configuration has this property defined */
+    fit_hdr = map_sysmem(addr, 0);
+    cfg_noffset = fit_conf_get_node(fit_hdr, images->fit_uname_cfg);
+    if (cfg_noffset < 0) {
+        debug("*  %s: no such config\n", prop_name);
+        return -EINVAL;
+    }
 
-	noffset = fit_conf_get_prop_node(fit_hdr, cfg_noffset, prop_name);
-	if (noffset < 0) {
-		debug("*  %s: no '%s' in config\n", prop_name, prop_name);
-		return -ENOENT;
-	}
+    noffset = fit_conf_get_prop_node(fit_hdr, cfg_noffset, prop_name);
+    if (noffset < 0) {
+        debug("*  %s: no '%s' in config\n", prop_name, prop_name);
+        return -ENOENT;
+    }
 
-	return noffset;
+    return noffset;
 }
 
 /**
@@ -1580,251 +1628,251 @@ int fit_get_node_from_config(bootm_headers_t *images, const char *prop_name,
  */
 static const char *fit_get_image_type_property(int type)
 {
-	/*
-	 * This is sort-of available in the uimage_type[] table in image.c
-	 * but we don't have access to the short name, and "fdt" is different
-	 * anyway. So let's just keep it here.
-	 */
-	switch (type) {
-	case IH_TYPE_FLATDT:
-		return FIT_FDT_PROP;
-	case IH_TYPE_KERNEL:
-		return FIT_KERNEL_PROP;
-	case IH_TYPE_RAMDISK:
-		return FIT_RAMDISK_PROP;
-	case IH_TYPE_X86_SETUP:
-		return FIT_SETUP_PROP;
-	case IH_TYPE_LOADABLE:
-		return FIT_LOADABLE_PROP;
-	case IH_TYPE_FPGA:
-		return FIT_FPGA_PROP;
-	}
+    /*
+     * This is sort-of available in the uimage_type[] table in image.c
+     * but we don't have access to the short name, and "fdt" is different
+     * anyway. So let's just keep it here.
+     */
+    switch (type) {
+    case IH_TYPE_FLATDT:
+        return FIT_FDT_PROP;
+    case IH_TYPE_KERNEL:
+        return FIT_KERNEL_PROP;
+    case IH_TYPE_RAMDISK:
+        return FIT_RAMDISK_PROP;
+    case IH_TYPE_X86_SETUP:
+        return FIT_SETUP_PROP;
+    case IH_TYPE_LOADABLE:
+        return FIT_LOADABLE_PROP;
+    case IH_TYPE_FPGA:
+        return FIT_FPGA_PROP;
+    }
 
-	return "unknown";
+    return "unknown";
 }
 
 int fit_image_load(bootm_headers_t *images, ulong addr,
-		   const char **fit_unamep, const char **fit_uname_configp,
-		   int arch, int image_type, int bootstage_id,
-		   enum fit_load_op load_op, ulong *datap, ulong *lenp)
+           const char **fit_unamep, const char **fit_uname_configp,
+           int arch, int image_type, int bootstage_id,
+           enum fit_load_op load_op, ulong *datap, ulong *lenp)
 {
-	int cfg_noffset, noffset;
-	const char *fit_uname;
-	const char *fit_uname_config;
-	const void *fit;
-	const void *buf;
-	size_t size;
-	int type_ok, os_ok;
-	ulong load, data, len;
-	uint8_t os;
-	const char *prop_name;
-	int ret;
+    int cfg_noffset, noffset;
+    const char *fit_uname;
+    const char *fit_uname_config;
+    const void *fit;
+    const void *buf;
+    size_t size;
+    int type_ok, os_ok;
+    ulong load, data, len;
+    uint8_t os;
+    const char *prop_name;
+    int ret;
 
-	fit = map_sysmem(addr, 0);
-	fit_uname = fit_unamep ? *fit_unamep : NULL;
-	fit_uname_config = fit_uname_configp ? *fit_uname_configp : NULL;
-	prop_name = fit_get_image_type_property(image_type);
-	printf("## Loading %s from FIT Image at %08lx ...\n", prop_name, addr);
+    fit = map_sysmem(addr, 0);
+    fit_uname = fit_unamep ? *fit_unamep : NULL;
+    fit_uname_config = fit_uname_configp ? *fit_uname_configp : NULL;
+    prop_name = fit_get_image_type_property(image_type);
+    printf("## Loading %s from FIT Image at %08lx ...\n", prop_name, addr);
 
-	bootstage_mark(bootstage_id + BOOTSTAGE_SUB_FORMAT);
-	if (!fit_check_format(fit)) {
-		printf("Bad FIT %s image format!\n", prop_name);
-		bootstage_error(bootstage_id + BOOTSTAGE_SUB_FORMAT);
-		return -ENOEXEC;
-	}
-	bootstage_mark(bootstage_id + BOOTSTAGE_SUB_FORMAT_OK);
-	if (fit_uname) {
-		/* get FIT component image node offset */
-		bootstage_mark(bootstage_id + BOOTSTAGE_SUB_UNIT_NAME);
-		noffset = fit_image_get_node(fit, fit_uname);
-	} else {
-		/*
-		 * no image node unit name, try to get config
-		 * node first. If config unit node name is NULL
-		 * fit_conf_get_node() will try to find default config node
-		 */
-		bootstage_mark(bootstage_id + BOOTSTAGE_SUB_NO_UNIT_NAME);
-		if (IMAGE_ENABLE_BEST_MATCH && !fit_uname_config) {
-			cfg_noffset = fit_conf_find_compat(fit, gd_fdt_blob());
-		} else {
-			cfg_noffset = fit_conf_get_node(fit,
-							fit_uname_config);
-		}
-		if (cfg_noffset < 0) {
-			puts("Could not find configuration node\n");
-			bootstage_error(bootstage_id +
-					BOOTSTAGE_SUB_NO_UNIT_NAME);
-			return -ENOENT;
-		}
-		fit_uname_config = fdt_get_name(fit, cfg_noffset, NULL);
-		printf("   Using '%s' configuration\n", fit_uname_config);
-		if (image_type == IH_TYPE_KERNEL) {
-			/* Remember (and possibly verify) this config */
-			images->fit_uname_cfg = fit_uname_config;
-			if (IMAGE_ENABLE_VERIFY && images->verify) {
-				puts("   Verifying Hash Integrity ... ");
-				if (fit_config_verify(fit, cfg_noffset)) {
-					puts("Bad Data Hash\n");
-					bootstage_error(bootstage_id +
-						BOOTSTAGE_SUB_HASH);
-					return -EACCES;
-				}
-				puts("OK\n");
-			}
-			bootstage_mark(BOOTSTAGE_ID_FIT_CONFIG);
-		}
+    bootstage_mark(bootstage_id + BOOTSTAGE_SUB_FORMAT);
+    if (!fit_check_format(fit)) {
+        printf("Bad FIT %s image format!\n", prop_name);
+        bootstage_error(bootstage_id + BOOTSTAGE_SUB_FORMAT);
+        return -ENOEXEC;
+    }
+    bootstage_mark(bootstage_id + BOOTSTAGE_SUB_FORMAT_OK);
+    if (fit_uname) {
+        /* get FIT component image node offset */
+        bootstage_mark(bootstage_id + BOOTSTAGE_SUB_UNIT_NAME);
+        noffset = fit_image_get_node(fit, fit_uname);
+    } else {
+        /*
+         * no image node unit name, try to get config
+         * node first. If config unit node name is NULL
+         * fit_conf_get_node() will try to find default config node
+         */
+        bootstage_mark(bootstage_id + BOOTSTAGE_SUB_NO_UNIT_NAME);
+        if (IMAGE_ENABLE_BEST_MATCH && !fit_uname_config) {
+            cfg_noffset = fit_conf_find_compat(fit, gd_fdt_blob());
+        } else {
+            cfg_noffset = fit_conf_get_node(fit,
+                            fit_uname_config);
+        }
+        if (cfg_noffset < 0) {
+            puts("Could not find configuration node\n");
+            bootstage_error(bootstage_id +
+                    BOOTSTAGE_SUB_NO_UNIT_NAME);
+            return -ENOENT;
+        }
+        fit_uname_config = fdt_get_name(fit, cfg_noffset, NULL);
+        printf("   Using '%s' configuration\n", fit_uname_config);
+        if (image_type == IH_TYPE_KERNEL) {
+            /* Remember (and possibly verify) this config */
+            images->fit_uname_cfg = fit_uname_config;
+            if (IMAGE_ENABLE_VERIFY && images->verify) {
+                puts("   Verifying Hash Integrity ... ");
+                if (fit_config_verify(fit, cfg_noffset)) {
+                    puts("Bad Data Hash\n");
+                    bootstage_error(bootstage_id +
+                        BOOTSTAGE_SUB_HASH);
+                    return -EACCES;
+                }
+                puts("OK\n");
+            }
+            bootstage_mark(BOOTSTAGE_ID_FIT_CONFIG);
+        }
 
-		noffset = fit_conf_get_prop_node(fit, cfg_noffset,
-						 prop_name);
-		fit_uname = fit_get_name(fit, noffset, NULL);
-	}
-	if (noffset < 0) {
-		puts("Could not find subimage node\n");
-		bootstage_error(bootstage_id + BOOTSTAGE_SUB_SUBNODE);
-		return -ENOENT;
-	}
+        noffset = fit_conf_get_prop_node(fit, cfg_noffset,
+                         prop_name);
+        fit_uname = fit_get_name(fit, noffset, NULL);
+    }
+    if (noffset < 0) {
+        puts("Could not find subimage node\n");
+        bootstage_error(bootstage_id + BOOTSTAGE_SUB_SUBNODE);
+        return -ENOENT;
+    }
 
-	printf("   Trying '%s' %s subimage\n", fit_uname, prop_name);
+    printf("   Trying '%s' %s subimage\n", fit_uname, prop_name);
 
-	ret = fit_image_select(fit, noffset, images->verify);
-	if (ret) {
-		bootstage_error(bootstage_id + BOOTSTAGE_SUB_HASH);
-		return ret;
-	}
+    ret = fit_image_select(fit, noffset, images->verify);
+    if (ret) {
+        bootstage_error(bootstage_id + BOOTSTAGE_SUB_HASH);
+        return ret;
+    }
 
-	bootstage_mark(bootstage_id + BOOTSTAGE_SUB_CHECK_ARCH);
+    bootstage_mark(bootstage_id + BOOTSTAGE_SUB_CHECK_ARCH);
 #if !defined(USE_HOSTCC) && !defined(CONFIG_SANDBOX)
-	if (!fit_image_check_target_arch(fit, noffset)) {
-		puts("Unsupported Architecture\n");
-		bootstage_error(bootstage_id + BOOTSTAGE_SUB_CHECK_ARCH);
-		return -ENOEXEC;
-	}
+    if (!fit_image_check_target_arch(fit, noffset)) {
+        puts("Unsupported Architecture\n");
+        bootstage_error(bootstage_id + BOOTSTAGE_SUB_CHECK_ARCH);
+        return -ENOEXEC;
+    }
 #endif
-	if (image_type == IH_TYPE_FLATDT &&
-	    !fit_image_check_comp(fit, noffset, IH_COMP_NONE)) {
-		puts("FDT image is compressed");
-		return -EPROTONOSUPPORT;
-	}
+    if (image_type == IH_TYPE_FLATDT &&
+        !fit_image_check_comp(fit, noffset, IH_COMP_NONE)) {
+        puts("FDT image is compressed");
+        return -EPROTONOSUPPORT;
+    }
 
-	bootstage_mark(bootstage_id + BOOTSTAGE_SUB_CHECK_ALL);
-	type_ok = fit_image_check_type(fit, noffset, image_type) ||
-		  fit_image_check_type(fit, noffset, IH_TYPE_FIRMWARE) ||
-		  (image_type == IH_TYPE_KERNEL &&
-		   fit_image_check_type(fit, noffset, IH_TYPE_KERNEL_NOLOAD));
+    bootstage_mark(bootstage_id + BOOTSTAGE_SUB_CHECK_ALL);
+    type_ok = fit_image_check_type(fit, noffset, image_type) ||
+          fit_image_check_type(fit, noffset, IH_TYPE_FIRMWARE) ||
+          (image_type == IH_TYPE_KERNEL &&
+           fit_image_check_type(fit, noffset, IH_TYPE_KERNEL_NOLOAD));
 
-	os_ok = image_type == IH_TYPE_FLATDT ||
-		image_type == IH_TYPE_FPGA ||
-		fit_image_check_os(fit, noffset, IH_OS_LINUX) ||
-		fit_image_check_os(fit, noffset, IH_OS_U_BOOT) ||
-		fit_image_check_os(fit, noffset, IH_OS_OPENRTOS);
+    os_ok = image_type == IH_TYPE_FLATDT ||
+        image_type == IH_TYPE_FPGA ||
+        fit_image_check_os(fit, noffset, IH_OS_LINUX) ||
+        fit_image_check_os(fit, noffset, IH_OS_U_BOOT) ||
+        fit_image_check_os(fit, noffset, IH_OS_OPENRTOS);
 
-	/*
-	 * If either of the checks fail, we should report an error, but
-	 * if the image type is coming from the "loadables" field, we
-	 * don't care what it is
-	 */
-	if ((!type_ok || !os_ok) && image_type != IH_TYPE_LOADABLE) {
-		fit_image_get_os(fit, noffset, &os);
-		printf("No %s %s %s Image\n",
-		       genimg_get_os_name(os),
-		       genimg_get_arch_name(arch),
-		       genimg_get_type_name(image_type));
-		bootstage_error(bootstage_id + BOOTSTAGE_SUB_CHECK_ALL);
-		return -EIO;
-	}
+    /*
+     * If either of the checks fail, we should report an error, but
+     * if the image type is coming from the "loadables" field, we
+     * don't care what it is
+     */
+    if ((!type_ok || !os_ok) && image_type != IH_TYPE_LOADABLE) {
+        fit_image_get_os(fit, noffset, &os);
+        printf("No %s %s %s Image\n",
+               genimg_get_os_name(os),
+               genimg_get_arch_name(arch),
+               genimg_get_type_name(image_type));
+        bootstage_error(bootstage_id + BOOTSTAGE_SUB_CHECK_ALL);
+        return -EIO;
+    }
 
-	bootstage_mark(bootstage_id + BOOTSTAGE_SUB_CHECK_ALL_OK);
+    bootstage_mark(bootstage_id + BOOTSTAGE_SUB_CHECK_ALL_OK);
 
-	/* get image data address and length */
-	if (fit_image_get_data(fit, noffset, &buf, &size)) {
-		printf("Could not find %s subimage data!\n", prop_name);
-		bootstage_error(bootstage_id + BOOTSTAGE_SUB_GET_DATA);
-		return -ENOENT;
-	}
-	len = (ulong)size;
+    /* get image data address and length */
+    if (fit_image_get_data(fit, noffset, &buf, &size)) {
+        printf("Could not find %s subimage data!\n", prop_name);
+        bootstage_error(bootstage_id + BOOTSTAGE_SUB_GET_DATA);
+        return -ENOENT;
+    }
+    len = (ulong)size;
 
-	/* verify that image data is a proper FDT blob */
-	if (image_type == IH_TYPE_FLATDT && fdt_check_header(buf)) {
-		puts("Subimage data is not a FDT");
-		return -ENOEXEC;
-	}
+    /* verify that image data is a proper FDT blob */
+    if (image_type == IH_TYPE_FLATDT && fdt_check_header(buf)) {
+        puts("Subimage data is not a FDT");
+        return -ENOEXEC;
+    }
 
-	bootstage_mark(bootstage_id + BOOTSTAGE_SUB_GET_DATA_OK);
+    bootstage_mark(bootstage_id + BOOTSTAGE_SUB_GET_DATA_OK);
 
-	/*
-	 * Work-around for eldk-4.2 which gives this warning if we try to
-	 * cast in the unmap_sysmem() call:
-	 * warning: initialization discards qualifiers from pointer target type
-	 */
-	{
-		void *vbuf = (void *)buf;
+    /*
+     * Work-around for eldk-4.2 which gives this warning if we try to
+     * cast in the unmap_sysmem() call:
+     * warning: initialization discards qualifiers from pointer target type
+     */
+    {
+        void *vbuf = (void *)buf;
 
-		data = map_to_sysmem(vbuf);
-	}
+        data = map_to_sysmem(vbuf);
+    }
 
-	if (load_op == FIT_LOAD_IGNORED) {
-		/* Don't load */
-	} else if (fit_image_get_load(fit, noffset, &load)) {
-		if (load_op == FIT_LOAD_REQUIRED) {
-			printf("Can't get %s subimage load address!\n",
-			       prop_name);
-			bootstage_error(bootstage_id + BOOTSTAGE_SUB_LOAD);
-			return -EBADF;
-		}
-	} else if (load_op != FIT_LOAD_OPTIONAL_NON_ZERO || load) {
-		ulong image_start, image_end;
-		ulong load_end;
-		void *dst;
+    if (load_op == FIT_LOAD_IGNORED) {
+        /* Don't load */
+    } else if (fit_image_get_load(fit, noffset, &load)) {
+        if (load_op == FIT_LOAD_REQUIRED) {
+            printf("Can't get %s subimage load address!\n",
+                   prop_name);
+            bootstage_error(bootstage_id + BOOTSTAGE_SUB_LOAD);
+            return -EBADF;
+        }
+    } else if (load_op != FIT_LOAD_OPTIONAL_NON_ZERO || load) {
+        ulong image_start, image_end;
+        ulong load_end;
+        void *dst;
 
-		/*
-		 * move image data to the load address,
-		 * make sure we don't overwrite initial image
-		 */
-		image_start = addr;
-		image_end = addr + fit_get_size(fit);
+        /*
+         * move image data to the load address,
+         * make sure we don't overwrite initial image
+         */
+        image_start = addr;
+        image_end = addr + fit_get_size(fit);
 
-		load_end = load + len;
-		if (image_type != IH_TYPE_KERNEL &&
-		    load < image_end && load_end > image_start) {
-			printf("Error: %s overwritten\n", prop_name);
-			return -EXDEV;
-		}
+        load_end = load + len;
+        if (image_type != IH_TYPE_KERNEL &&
+            load < image_end && load_end > image_start) {
+            printf("Error: %s overwritten\n", prop_name);
+            return -EXDEV;
+        }
 
-		printf("   Loading %s from 0x%08lx to 0x%08lx\n",
-		       prop_name, data, load);
+        printf("   Loading %s from 0x%08lx to 0x%08lx\n",
+               prop_name, data, load);
 
-		dst = map_sysmem(load, len);
-		memmove(dst, buf, len);
-		data = load;
-	}
-	bootstage_mark(bootstage_id + BOOTSTAGE_SUB_LOAD);
+        dst = map_sysmem(load, len);
+        memmove(dst, buf, len);
+        data = load;
+    }
+    bootstage_mark(bootstage_id + BOOTSTAGE_SUB_LOAD);
 
-	*datap = data;
-	*lenp = len;
-	if (fit_unamep)
-		*fit_unamep = (char *)fit_uname;
-	if (fit_uname_configp)
-		*fit_uname_configp = (char *)fit_uname_config;
+    *datap = data;
+    *lenp = len;
+    if (fit_unamep)
+        *fit_unamep = (char *)fit_uname;
+    if (fit_uname_configp)
+        *fit_uname_configp = (char *)fit_uname_config;
 
-	return noffset;
+    return noffset;
 }
 
 int boot_get_setup_fit(bootm_headers_t *images, uint8_t arch,
-			ulong *setup_start, ulong *setup_len)
+            ulong *setup_start, ulong *setup_len)
 {
-	int noffset;
-	ulong addr;
-	ulong len;
-	int ret;
+    int noffset;
+    ulong addr;
+    ulong len;
+    int ret;
 
-	addr = map_to_sysmem(images->fit_hdr_os);
-	noffset = fit_get_node_from_config(images, FIT_SETUP_PROP, addr);
-	if (noffset < 0)
-		return noffset;
+    addr = map_to_sysmem(images->fit_hdr_os);
+    noffset = fit_get_node_from_config(images, FIT_SETUP_PROP, addr);
+    if (noffset < 0)
+        return noffset;
 
-	ret = fit_image_load(images, addr, NULL, NULL, arch,
-			     IH_TYPE_X86_SETUP, BOOTSTAGE_ID_FIT_SETUP_START,
-			     FIT_LOAD_REQUIRED, setup_start, &len);
+    ret = fit_image_load(images, addr, NULL, NULL, arch,
+                 IH_TYPE_X86_SETUP, BOOTSTAGE_ID_FIT_SETUP_START,
+                 FIT_LOAD_REQUIRED, setup_start, &len);
 
-	return ret;
+    return ret;
 }

--- a/common/image-fit.c
+++ b/common/image-fit.c
@@ -6,7 +6,7 @@
  * (C) Copyright 2000-2006
  * Wolfgang Denk, DENX Software Engineering, wd@denx.de.
  *
- * SPDX-License-Identifier: GPL-2.0+
+ * SPDX-License-Identifier:	GPL-2.0+
  */
 
 #ifdef USE_HOSTCC
@@ -33,23 +33,23 @@ DECLARE_GLOBAL_DATA_PTR;
 /*****************************************************************************/
 #ifndef USE_HOSTCC
 static int fit_parse_spec(const char *spec, char sepc, ulong addr_curr,
-        ulong *addr, const char **name)
+		ulong *addr, const char **name)
 {
-    const char *sep;
+	const char *sep;
 
-    *addr = addr_curr;
-    *name = NULL;
+	*addr = addr_curr;
+	*name = NULL;
 
-    sep = strchr(spec, sepc);
-    if (sep) {
-        if (sep - spec > 0)
-            *addr = simple_strtoul(spec, NULL, 16);
+	sep = strchr(spec, sepc);
+	if (sep) {
+		if (sep - spec > 0)
+			*addr = simple_strtoul(spec, NULL, 16);
 
-        *name = sep + 1;
-        return 1;
-    }
+		*name = sep + 1;
+		return 1;
+	}
 
-    return 0;
+	return 0;
 }
 
 /**
@@ -74,9 +74,9 @@ static int fit_parse_spec(const char *spec, char sepc, ulong addr_curr,
  *     0 otherwise
  */
 int fit_parse_conf(const char *spec, ulong addr_curr,
-        ulong *addr, const char **conf_name)
+		ulong *addr, const char **conf_name)
 {
-    return fit_parse_spec(spec, '#', addr_curr, addr, conf_name);
+	return fit_parse_spec(spec, '#', addr_curr, addr, conf_name);
 }
 
 /**
@@ -100,18 +100,18 @@ int fit_parse_conf(const char *spec, ulong addr_curr,
  *     0 otherwise
  */
 int fit_parse_subimage(const char *spec, ulong addr_curr,
-        ulong *addr, const char **image_name)
+		ulong *addr, const char **image_name)
 {
-    return fit_parse_spec(spec, ':', addr_curr, addr, image_name);
+	return fit_parse_spec(spec, ':', addr_curr, addr, image_name);
 }
 #endif /* !USE_HOSTCC */
 
 static void fit_get_debug(const void *fit, int noffset,
-        char *prop_name, int err)
+		char *prop_name, int err)
 {
-    debug("Can't get '%s' property from FIT 0x%08lx, node: offset %d, name %s (%s)\n",
-          prop_name, (ulong)fit, noffset, fit_get_name(fit, noffset, NULL),
-          fdt_strerror(err));
+	debug("Can't get '%s' property from FIT 0x%08lx, node: offset %d, name %s (%s)\n",
+	      prop_name, (ulong)fit, noffset, fit_get_name(fit, noffset, NULL),
+	      fdt_strerror(err));
 }
 
 /**
@@ -124,21 +124,21 @@ static void fit_get_debug(const void *fit, int noffset,
  */
 int fit_get_subimage_count(const void *fit, int images_noffset)
 {
-    int noffset;
-    int ndepth;
-    int count = 0;
+	int noffset;
+	int ndepth;
+	int count = 0;
 
-    /* Process its subnodes, print out component images details */
-    for (ndepth = 0, count = 0,
-        noffset = fdt_next_node(fit, images_noffset, &ndepth);
-         (noffset >= 0) && (ndepth > 0);
-         noffset = fdt_next_node(fit, noffset, &ndepth)) {
-        if (ndepth == 1) {
-            count++;
-        }
-    }
+	/* Process its subnodes, print out component images details */
+	for (ndepth = 0, count = 0,
+		noffset = fdt_next_node(fit, images_noffset, &ndepth);
+	     (noffset >= 0) && (ndepth > 0);
+	     noffset = fdt_next_node(fit, noffset, &ndepth)) {
+		if (ndepth == 1) {
+			count++;
+		}
+	}
 
-    return count;
+	return count;
 }
 
 #if !defined(CONFIG_SPL_BUILD) || defined(CONFIG_FIT_SPL_PRINT)
@@ -156,91 +156,91 @@ int fit_get_subimage_count(const void *fit, int images_noffset)
  */
 void fit_print_contents(const void *fit)
 {
-    char *desc;
-    char *uname;
-    int images_noffset;
-    int confs_noffset;
-    int noffset;
-    int ndepth;
-    int count = 0;
-    int ret;
-    const char *p;
-    time_t timestamp;
+	char *desc;
+	char *uname;
+	int images_noffset;
+	int confs_noffset;
+	int noffset;
+	int ndepth;
+	int count = 0;
+	int ret;
+	const char *p;
+	time_t timestamp;
 
-    /* Indent string is defined in header image.h */
-    p = IMAGE_INDENT_STRING;
+	/* Indent string is defined in header image.h */
+	p = IMAGE_INDENT_STRING;
 
-    /* Root node properties */
-    ret = fit_get_desc(fit, 0, &desc);
-    printf("%sFIT description: ", p);
-    if (ret)
-        printf("unavailable\n");
-    else
-        printf("%s\n", desc);
+	/* Root node properties */
+	ret = fit_get_desc(fit, 0, &desc);
+	printf("%sFIT description: ", p);
+	if (ret)
+		printf("unavailable\n");
+	else
+		printf("%s\n", desc);
 
-    if (IMAGE_ENABLE_TIMESTAMP) {
-        ret = fit_get_timestamp(fit, 0, &timestamp);
-        printf("%sCreated:         ", p);
-        if (ret)
-            printf("unavailable\n");
-        else
-            genimg_print_time(timestamp);
-    }
+	if (IMAGE_ENABLE_TIMESTAMP) {
+		ret = fit_get_timestamp(fit, 0, &timestamp);
+		printf("%sCreated:         ", p);
+		if (ret)
+			printf("unavailable\n");
+		else
+			genimg_print_time(timestamp);
+	}
 
-    /* Find images parent node offset */
-    images_noffset = fdt_path_offset(fit, FIT_IMAGES_PATH);
-    if (images_noffset < 0) {
-        printf("Can't find images parent node '%s' (%s)\n",
-               FIT_IMAGES_PATH, fdt_strerror(images_noffset));
-        return;
-    }
+	/* Find images parent node offset */
+	images_noffset = fdt_path_offset(fit, FIT_IMAGES_PATH);
+	if (images_noffset < 0) {
+		printf("Can't find images parent node '%s' (%s)\n",
+		       FIT_IMAGES_PATH, fdt_strerror(images_noffset));
+		return;
+	}
 
-    /* Process its subnodes, print out component images details */
-    for (ndepth = 0, count = 0,
-        noffset = fdt_next_node(fit, images_noffset, &ndepth);
-         (noffset >= 0) && (ndepth > 0);
-         noffset = fdt_next_node(fit, noffset, &ndepth)) {
-        if (ndepth == 1) {
-            /*
-             * Direct child node of the images parent node,
-             * i.e. component image node.
-             */
-            printf("%s Image %u (%s)\n", p, count++,
-                   fit_get_name(fit, noffset, NULL));
+	/* Process its subnodes, print out component images details */
+	for (ndepth = 0, count = 0,
+		noffset = fdt_next_node(fit, images_noffset, &ndepth);
+	     (noffset >= 0) && (ndepth > 0);
+	     noffset = fdt_next_node(fit, noffset, &ndepth)) {
+		if (ndepth == 1) {
+			/*
+			 * Direct child node of the images parent node,
+			 * i.e. component image node.
+			 */
+			printf("%s Image %u (%s)\n", p, count++,
+			       fit_get_name(fit, noffset, NULL));
 
-            fit_image_print(fit, noffset, p);
-        }
-    }
+			fit_image_print(fit, noffset, p);
+		}
+	}
 
-    /* Find configurations parent node offset */
-    confs_noffset = fdt_path_offset(fit, FIT_CONFS_PATH);
-    if (confs_noffset < 0) {
-        debug("Can't get configurations parent node '%s' (%s)\n",
-              FIT_CONFS_PATH, fdt_strerror(confs_noffset));
-        return;
-    }
+	/* Find configurations parent node offset */
+	confs_noffset = fdt_path_offset(fit, FIT_CONFS_PATH);
+	if (confs_noffset < 0) {
+		debug("Can't get configurations parent node '%s' (%s)\n",
+		      FIT_CONFS_PATH, fdt_strerror(confs_noffset));
+		return;
+	}
 
-    /* get default configuration unit name from default property */
-    uname = (char *)fdt_getprop(fit, noffset, FIT_DEFAULT_PROP, NULL);
-    if (uname)
-        printf("%s Default Configuration: '%s'\n", p, uname);
+	/* get default configuration unit name from default property */
+	uname = (char *)fdt_getprop(fit, noffset, FIT_DEFAULT_PROP, NULL);
+	if (uname)
+		printf("%s Default Configuration: '%s'\n", p, uname);
 
-    /* Process its subnodes, print out configurations details */
-    for (ndepth = 0, count = 0,
-        noffset = fdt_next_node(fit, confs_noffset, &ndepth);
-         (noffset >= 0) && (ndepth > 0);
-         noffset = fdt_next_node(fit, noffset, &ndepth)) {
-        if (ndepth == 1) {
-            /*
-             * Direct child node of the configurations parent node,
-             * i.e. configuration node.
-             */
-            printf("%s Configuration %u (%s)\n", p, count++,
-                   fit_get_name(fit, noffset, NULL));
+	/* Process its subnodes, print out configurations details */
+	for (ndepth = 0, count = 0,
+		noffset = fdt_next_node(fit, confs_noffset, &ndepth);
+	     (noffset >= 0) && (ndepth > 0);
+	     noffset = fdt_next_node(fit, noffset, &ndepth)) {
+		if (ndepth == 1) {
+			/*
+			 * Direct child node of the configurations parent node,
+			 * i.e. configuration node.
+			 */
+			printf("%s Configuration %u (%s)\n", p, count++,
+			       fit_get_name(fit, noffset, NULL));
 
-            fit_conf_print(fit, noffset, p);
-        }
-    }
+			fit_conf_print(fit, noffset, p);
+		}
+	}
 }
 
 /**
@@ -259,54 +259,54 @@ void fit_print_contents(const void *fit)
  *     no returned results
  */
 static void fit_image_print_data(const void *fit, int noffset, const char *p,
-                 const char *type)
+				 const char *type)
 {
-    const char *keyname;
-    uint8_t *value;
-    int value_len;
-    char *algo;
-    int required;
-    int ret, i;
+	const char *keyname;
+	uint8_t *value;
+	int value_len;
+	char *algo;
+	int required;
+	int ret, i;
 
-    debug("%s  %s node:    '%s'\n", p, type,
-          fit_get_name(fit, noffset, NULL));
-    printf("%s  %s algo:    ", p, type);
-    if (fit_image_hash_get_algo(fit, noffset, &algo)) {
-        printf("invalid/unsupported\n");
-        return;
-    }
-    printf("%s", algo);
-    keyname = fdt_getprop(fit, noffset, "key-name-hint", NULL);
-    required = fdt_getprop(fit, noffset, "required", NULL) != NULL;
-    if (keyname)
-        printf(":%s", keyname);
-    if (required)
-        printf(" (required)");
-    printf("\n");
+	debug("%s  %s node:    '%s'\n", p, type,
+	      fit_get_name(fit, noffset, NULL));
+	printf("%s  %s algo:    ", p, type);
+	if (fit_image_hash_get_algo(fit, noffset, &algo)) {
+		printf("invalid/unsupported\n");
+		return;
+	}
+	printf("%s", algo);
+	keyname = fdt_getprop(fit, noffset, "key-name-hint", NULL);
+	required = fdt_getprop(fit, noffset, "required", NULL) != NULL;
+	if (keyname)
+		printf(":%s", keyname);
+	if (required)
+		printf(" (required)");
+	printf("\n");
 
-    ret = fit_image_hash_get_value(fit, noffset, &value,
-                    &value_len);
-    printf("%s  %s value:   ", p, type);
-    if (ret) {
-        printf("unavailable\n");
-    } else {
-        for (i = 0; i < value_len; i++)
-            printf("%02x", value[i]);
-        printf("\n");
-    }
+	ret = fit_image_hash_get_value(fit, noffset, &value,
+					&value_len);
+	printf("%s  %s value:   ", p, type);
+	if (ret) {
+		printf("unavailable\n");
+	} else {
+		for (i = 0; i < value_len; i++)
+			printf("%02x", value[i]);
+		printf("\n");
+	}
 
-    debug("%s  %s len:     %d\n", p, type, value_len);
+	debug("%s  %s len:     %d\n", p, type, value_len);
 
-    /* Signatures have a time stamp */
-    if (IMAGE_ENABLE_TIMESTAMP && keyname) {
-        time_t timestamp;
+	/* Signatures have a time stamp */
+	if (IMAGE_ENABLE_TIMESTAMP && keyname) {
+		time_t timestamp;
 
-        printf("%s  Timestamp:    ", p);
-        if (fit_get_timestamp(fit, noffset, &timestamp))
-            printf("unavailable\n");
-        else
-            genimg_print_time(timestamp);
-    }
+		printf("%s  Timestamp:    ", p);
+		if (fit_get_timestamp(fit, noffset, &timestamp))
+			printf("unavailable\n");
+		else
+			genimg_print_time(timestamp);
+	}
 }
 
 /**
@@ -321,22 +321,22 @@ static void fit_image_print_data(const void *fit, int noffset, const char *p,
  *     no returned results
  */
 static void fit_image_print_verification_data(const void *fit, int noffset,
-                       const char *p)
+				       const char *p)
 {
-    const char *name;
+	const char *name;
 
-    /*
-     * Check subnode name, must be equal to "hash" or "signature".
-     * Multiple hash/signature nodes require unique unit node
-     * names, e.g. hash@1, hash@2, signature@1, signature@2, etc.
-     */
-    name = fit_get_name(fit, noffset, NULL);
-    if (!strncmp(name, FIT_HASH_NODENAME, strlen(FIT_HASH_NODENAME))) {
-        fit_image_print_data(fit, noffset, p, "Hash");
-    } else if (!strncmp(name, FIT_SIG_NODENAME,
-                strlen(FIT_SIG_NODENAME))) {
-        fit_image_print_data(fit, noffset, p, "Sign");
-    }
+	/*
+	 * Check subnode name, must be equal to "hash" or "signature".
+	 * Multiple hash/signature nodes require unique unit node
+	 * names, e.g. hash@1, hash@2, signature@1, signature@2, etc.
+	 */
+	name = fit_get_name(fit, noffset, NULL);
+	if (!strncmp(name, FIT_HASH_NODENAME, strlen(FIT_HASH_NODENAME))) {
+		fit_image_print_data(fit, noffset, p, "Hash");
+	} else if (!strncmp(name, FIT_SIG_NODENAME,
+				strlen(FIT_SIG_NODENAME))) {
+		fit_image_print_data(fit, noffset, p, "Sign");
+	}
 }
 
 /**
@@ -356,102 +356,102 @@ static void fit_image_print_verification_data(const void *fit, int noffset,
  */
 void fit_image_print(const void *fit, int image_noffset, const char *p)
 {
-    char *desc;
-    uint8_t type, arch, os, comp;
-    size_t size;
-    ulong load, entry;
-    const void *data;
-    int noffset;
-    int ndepth;
-    int ret;
+	char *desc;
+	uint8_t type, arch, os, comp;
+	size_t size;
+	ulong load, entry;
+	const void *data;
+	int noffset;
+	int ndepth;
+	int ret;
 
-    /* Mandatory properties */
-    ret = fit_get_desc(fit, image_noffset, &desc);
-    printf("%s  Description:  ", p);
-    if (ret)
-        printf("unavailable\n");
-    else
-        printf("%s\n", desc);
+	/* Mandatory properties */
+	ret = fit_get_desc(fit, image_noffset, &desc);
+	printf("%s  Description:  ", p);
+	if (ret)
+		printf("unavailable\n");
+	else
+		printf("%s\n", desc);
 
-    if (IMAGE_ENABLE_TIMESTAMP) {
-        time_t timestamp;
+	if (IMAGE_ENABLE_TIMESTAMP) {
+		time_t timestamp;
 
-        ret = fit_get_timestamp(fit, 0, &timestamp);
-        printf("%s  Created:      ", p);
-        if (ret)
-            printf("unavailable\n");
-        else
-            genimg_print_time(timestamp);
-    }
+		ret = fit_get_timestamp(fit, 0, &timestamp);
+		printf("%s  Created:      ", p);
+		if (ret)
+			printf("unavailable\n");
+		else
+			genimg_print_time(timestamp);
+	}
 
-    fit_image_get_type(fit, image_noffset, &type);
-    printf("%s  Type:         %s\n", p, genimg_get_type_name(type));
+	fit_image_get_type(fit, image_noffset, &type);
+	printf("%s  Type:         %s\n", p, genimg_get_type_name(type));
 
-    fit_image_get_comp(fit, image_noffset, &comp);
-    printf("%s  Compression:  %s\n", p, genimg_get_comp_name(comp));
+	fit_image_get_comp(fit, image_noffset, &comp);
+	printf("%s  Compression:  %s\n", p, genimg_get_comp_name(comp));
 
-    ret = fit_image_get_data(fit, image_noffset, &data, &size);
+	ret = fit_image_get_data(fit, image_noffset, &data, &size);
 
 #ifndef USE_HOSTCC
-    printf("%s  Data Start:   ", p);
-    if (ret) {
-        printf("unavailable\n");
-    } else {
-        void *vdata = (void *)data;
+	printf("%s  Data Start:   ", p);
+	if (ret) {
+		printf("unavailable\n");
+	} else {
+		void *vdata = (void *)data;
 
-        printf("0x%08lx\n", (ulong)map_to_sysmem(vdata));
-    }
+		printf("0x%08lx\n", (ulong)map_to_sysmem(vdata));
+	}
 #endif
 
-    printf("%s  Data Size:    ", p);
-    if (ret)
-        printf("unavailable\n");
-    else
-        genimg_print_size(size);
+	printf("%s  Data Size:    ", p);
+	if (ret)
+		printf("unavailable\n");
+	else
+		genimg_print_size(size);
 
-    /* Remaining, type dependent properties */
-    if ((type == IH_TYPE_KERNEL) || (type == IH_TYPE_STANDALONE) ||
-        (type == IH_TYPE_RAMDISK) || (type == IH_TYPE_FIRMWARE) ||
-        (type == IH_TYPE_FLATDT)) {
-        fit_image_get_arch(fit, image_noffset, &arch);
-        printf("%s  Architecture: %s\n", p, genimg_get_arch_name(arch));
-    }
+	/* Remaining, type dependent properties */
+	if ((type == IH_TYPE_KERNEL) || (type == IH_TYPE_STANDALONE) ||
+	    (type == IH_TYPE_RAMDISK) || (type == IH_TYPE_FIRMWARE) ||
+	    (type == IH_TYPE_FLATDT)) {
+		fit_image_get_arch(fit, image_noffset, &arch);
+		printf("%s  Architecture: %s\n", p, genimg_get_arch_name(arch));
+	}
 
-    if ((type == IH_TYPE_KERNEL) || (type == IH_TYPE_RAMDISK)) {
-        fit_image_get_os(fit, image_noffset, &os);
-        printf("%s  OS:           %s\n", p, genimg_get_os_name(os));
-    }
+	if ((type == IH_TYPE_KERNEL) || (type == IH_TYPE_RAMDISK)) {
+		fit_image_get_os(fit, image_noffset, &os);
+		printf("%s  OS:           %s\n", p, genimg_get_os_name(os));
+	}
 
-    if ((type == IH_TYPE_KERNEL) || (type == IH_TYPE_STANDALONE) ||
-        (type == IH_TYPE_FIRMWARE) || (type == IH_TYPE_RAMDISK) ||
-        (type == IH_TYPE_FPGA)) {
-        ret = fit_image_get_load(fit, image_noffset, &load);
-        printf("%s  Load Address: ", p);
-        if (ret)
-            printf("unavailable\n");
-        else
-            printf("0x%08lx\n", load);
-    }
+	if ((type == IH_TYPE_KERNEL) || (type == IH_TYPE_STANDALONE) ||
+	    (type == IH_TYPE_FIRMWARE) || (type == IH_TYPE_RAMDISK) ||
+	    (type == IH_TYPE_FPGA)) {
+		ret = fit_image_get_load(fit, image_noffset, &load);
+		printf("%s  Load Address: ", p);
+		if (ret)
+			printf("unavailable\n");
+		else
+			printf("0x%08lx\n", load);
+	}
 
-    if ((type == IH_TYPE_KERNEL) || (type == IH_TYPE_STANDALONE) ||
-        (type == IH_TYPE_RAMDISK)) {
-        ret = fit_image_get_entry(fit, image_noffset, &entry);
-        printf("%s  Entry Point:  ", p);
-        if (ret)
-            printf("unavailable\n");
-        else
-            printf("0x%08lx\n", entry);
-    }
+	if ((type == IH_TYPE_KERNEL) || (type == IH_TYPE_STANDALONE) ||
+	    (type == IH_TYPE_RAMDISK)) {
+		ret = fit_image_get_entry(fit, image_noffset, &entry);
+		printf("%s  Entry Point:  ", p);
+		if (ret)
+			printf("unavailable\n");
+		else
+			printf("0x%08lx\n", entry);
+	}
 
-    /* Process all hash subnodes of the component image node */
-    for (ndepth = 0, noffset = fdt_next_node(fit, image_noffset, &ndepth);
-         (noffset >= 0) && (ndepth > 0);
-         noffset = fdt_next_node(fit, noffset, &ndepth)) {
-        if (ndepth == 1) {
-            /* Direct child node of the component image node */
-            fit_image_print_verification_data(fit, noffset, p);
-        }
-    }
+	/* Process all hash subnodes of the component image node */
+	for (ndepth = 0, noffset = fdt_next_node(fit, image_noffset, &ndepth);
+	     (noffset >= 0) && (ndepth > 0);
+	     noffset = fdt_next_node(fit, noffset, &ndepth)) {
+		if (ndepth == 1) {
+			/* Direct child node of the component image node */
+			fit_image_print_verification_data(fit, noffset, p);
+		}
+	}
 }
 
 #endif /* !defined(CONFIG_SPL_BUILD) || defined(CONFIG_FIT_SPL_PRINT) */
@@ -471,15 +471,15 @@ void fit_image_print(const void *fit, int image_noffset, const char *p)
  */
 int fit_get_desc(const void *fit, int noffset, char **desc)
 {
-    int len;
+	int len;
 
-    *desc = (char *)fdt_getprop(fit, noffset, FIT_DESC_PROP, &len);
-    if (*desc == NULL) {
-        fit_get_debug(fit, noffset, FIT_DESC_PROP, len);
-        return -1;
-    }
+	*desc = (char *)fdt_getprop(fit, noffset, FIT_DESC_PROP, &len);
+	if (*desc == NULL) {
+		fit_get_debug(fit, noffset, FIT_DESC_PROP, len);
+		return -1;
+	}
 
-    return 0;
+	return 0;
 }
 
 /**
@@ -499,21 +499,21 @@ int fit_get_desc(const void *fit, int noffset, char **desc)
  */
 int fit_get_timestamp(const void *fit, int noffset, time_t *timestamp)
 {
-    int len;
-    const void *data;
+	int len;
+	const void *data;
 
-    data = fdt_getprop(fit, noffset, FIT_TIMESTAMP_PROP, &len);
-    if (data == NULL) {
-        fit_get_debug(fit, noffset, FIT_TIMESTAMP_PROP, len);
-        return -1;
-    }
-    if (len != sizeof(uint32_t)) {
-        debug("FIT timestamp with incorrect size of (%u)\n", len);
-        return -2;
-    }
+	data = fdt_getprop(fit, noffset, FIT_TIMESTAMP_PROP, &len);
+	if (data == NULL) {
+		fit_get_debug(fit, noffset, FIT_TIMESTAMP_PROP, len);
+		return -1;
+	}
+	if (len != sizeof(uint32_t)) {
+		debug("FIT timestamp with incorrect size of (%u)\n", len);
+		return -2;
+	}
 
-    *timestamp = uimage_to_cpu(*((uint32_t *)data));
-    return 0;
+	*timestamp = uimage_to_cpu(*((uint32_t *)data));
+	return 0;
 }
 
 /**
@@ -531,22 +531,22 @@ int fit_get_timestamp(const void *fit, int noffset, time_t *timestamp)
  */
 int fit_image_get_node(const void *fit, const char *image_uname)
 {
-    int noffset, images_noffset;
+	int noffset, images_noffset;
 
-    images_noffset = fdt_path_offset(fit, FIT_IMAGES_PATH);
-    if (images_noffset < 0) {
-        debug("Can't find images parent node '%s' (%s)\n",
-              FIT_IMAGES_PATH, fdt_strerror(images_noffset));
-        return images_noffset;
-    }
+	images_noffset = fdt_path_offset(fit, FIT_IMAGES_PATH);
+	if (images_noffset < 0) {
+		debug("Can't find images parent node '%s' (%s)\n",
+		      FIT_IMAGES_PATH, fdt_strerror(images_noffset));
+		return images_noffset;
+	}
 
-    noffset = fdt_subnode_offset(fit, images_noffset, image_uname);
-    if (noffset < 0) {
-        debug("Can't get node offset for image unit name: '%s' (%s)\n",
-              image_uname, fdt_strerror(noffset));
-    }
+	noffset = fdt_subnode_offset(fit, images_noffset, image_uname);
+	if (noffset < 0) {
+		debug("Can't get node offset for image unit name: '%s' (%s)\n",
+		      image_uname, fdt_strerror(noffset));
+	}
 
-    return noffset;
+	return noffset;
 }
 
 /**
@@ -565,20 +565,20 @@ int fit_image_get_node(const void *fit, const char *image_uname)
  */
 int fit_image_get_os(const void *fit, int noffset, uint8_t *os)
 {
-    int len;
-    const void *data;
+	int len;
+	const void *data;
 
-    /* Get OS name from property data */
-    data = fdt_getprop(fit, noffset, FIT_OS_PROP, &len);
-    if (data == NULL) {
-        fit_get_debug(fit, noffset, FIT_OS_PROP, len);
-        *os = -1;
-        return -1;
-    }
+	/* Get OS name from property data */
+	data = fdt_getprop(fit, noffset, FIT_OS_PROP, &len);
+	if (data == NULL) {
+		fit_get_debug(fit, noffset, FIT_OS_PROP, len);
+		*os = -1;
+		return -1;
+	}
 
-    /* Translate OS name to id */
-    *os = genimg_get_os_id(data);
-    return 0;
+	/* Translate OS name to id */
+	*os = genimg_get_os_id(data);
+	return 0;
 }
 
 /**
@@ -597,20 +597,20 @@ int fit_image_get_os(const void *fit, int noffset, uint8_t *os)
  */
 int fit_image_get_arch(const void *fit, int noffset, uint8_t *arch)
 {
-    int len;
-    const void *data;
+	int len;
+	const void *data;
 
-    /* Get architecture name from property data */
-    data = fdt_getprop(fit, noffset, FIT_ARCH_PROP, &len);
-    if (data == NULL) {
-        fit_get_debug(fit, noffset, FIT_ARCH_PROP, len);
-        *arch = -1;
-        return -1;
-    }
+	/* Get architecture name from property data */
+	data = fdt_getprop(fit, noffset, FIT_ARCH_PROP, &len);
+	if (data == NULL) {
+		fit_get_debug(fit, noffset, FIT_ARCH_PROP, len);
+		*arch = -1;
+		return -1;
+	}
 
-    /* Translate architecture name to id */
-    *arch = genimg_get_arch_id(data);
-    return 0;
+	/* Translate architecture name to id */
+	*arch = genimg_get_arch_id(data);
+	return 0;
 }
 
 /**
@@ -629,20 +629,20 @@ int fit_image_get_arch(const void *fit, int noffset, uint8_t *arch)
  */
 int fit_image_get_type(const void *fit, int noffset, uint8_t *type)
 {
-    int len;
-    const void *data;
+	int len;
+	const void *data;
 
-    /* Get image type name from property data */
-    data = fdt_getprop(fit, noffset, FIT_TYPE_PROP, &len);
-    if (data == NULL) {
-        fit_get_debug(fit, noffset, FIT_TYPE_PROP, len);
-        *type = -1;
-        return -1;
-    }
+	/* Get image type name from property data */
+	data = fdt_getprop(fit, noffset, FIT_TYPE_PROP, &len);
+	if (data == NULL) {
+		fit_get_debug(fit, noffset, FIT_TYPE_PROP, len);
+		*type = -1;
+		return -1;
+	}
 
-    /* Translate image type name to id */
-    *type = genimg_get_type_id(data);
-    return 0;
+	/* Translate image type name to id */
+	*type = genimg_get_type_id(data);
+	return 0;
 }
 
 /**
@@ -661,49 +661,49 @@ int fit_image_get_type(const void *fit, int noffset, uint8_t *type)
  */
 int fit_image_get_comp(const void *fit, int noffset, uint8_t *comp)
 {
-    int len;
-    const void *data;
+	int len;
+	const void *data;
 
-    /* Get compression name from property data */
-    data = fdt_getprop(fit, noffset, FIT_COMP_PROP, &len);
-    if (data == NULL) {
-        fit_get_debug(fit, noffset, FIT_COMP_PROP, len);
-        *comp = -1;
-        return -1;
-    }
+	/* Get compression name from property data */
+	data = fdt_getprop(fit, noffset, FIT_COMP_PROP, &len);
+	if (data == NULL) {
+		fit_get_debug(fit, noffset, FIT_COMP_PROP, len);
+		*comp = -1;
+		return -1;
+	}
 
-    /* Translate compression name to id */
-    *comp = genimg_get_comp_id(data);
-    return 0;
+	/* Translate compression name to id */
+	*comp = genimg_get_comp_id(data);
+	return 0;
 }
 
 static int fit_image_get_address(const void *fit, int noffset, char *name,
-              ulong *load)
+			  ulong *load)
 {
-    int len, cell_len;
-    const fdt32_t *cell;
-    uint64_t load64 = 0;
+	int len, cell_len;
+	const fdt32_t *cell;
+	uint64_t load64 = 0;
 
-    cell = fdt_getprop(fit, noffset, name, &len);
-    if (cell == NULL) {
-        fit_get_debug(fit, noffset, name, len);
-        return -1;
-    }
+	cell = fdt_getprop(fit, noffset, name, &len);
+	if (cell == NULL) {
+		fit_get_debug(fit, noffset, name, len);
+		return -1;
+	}
 
-    if (len > sizeof(ulong)) {
-        printf("Unsupported %s address size\n", name);
-        return -1;
-    }
+	if (len > sizeof(ulong)) {
+		printf("Unsupported %s address size\n", name);
+		return -1;
+	}
 
-    cell_len = len >> 2;
-    /* Use load64 to avoid compiling warning for 32-bit target */
-    while (cell_len--) {
-        load64 = (load64 << 32) | uimage_to_cpu(*cell);
-        cell++;
-    }
-    *load = (ulong)load64;
+	cell_len = len >> 2;
+	/* Use load64 to avoid compiling warning for 32-bit target */
+	while (cell_len--) {
+		load64 = (load64 << 32) | uimage_to_cpu(*cell);
+		cell++;
+	}
+	*load = (ulong)load64;
 
-    return 0;
+	return 0;
 }
 /**
  * fit_image_get_load() - get load addr property for given component image node
@@ -720,7 +720,7 @@ static int fit_image_get_address(const void *fit, int noffset, char *name,
  */
 int fit_image_get_load(const void *fit, int noffset, ulong *load)
 {
-    return fit_image_get_address(fit, noffset, FIT_LOAD_PROP, load);
+	return fit_image_get_address(fit, noffset, FIT_LOAD_PROP, load);
 }
 
 /**
@@ -742,7 +742,7 @@ int fit_image_get_load(const void *fit, int noffset, ulong *load)
  */
 int fit_image_get_entry(const void *fit, int noffset, ulong *entry)
 {
-    return fit_image_get_address(fit, noffset, FIT_ENTRY_PROP, entry);
+	return fit_image_get_address(fit, noffset, FIT_ENTRY_PROP, entry);
 }
 
 /**
@@ -761,19 +761,19 @@ int fit_image_get_entry(const void *fit, int noffset, ulong *entry)
  *     -1, on failure
  */
 int fit_image_get_data(const void *fit, int noffset,
-        const void **data, size_t *size)
+		const void **data, size_t *size)
 {
-    int len;
+	int len;
 
-    *data = fdt_getprop(fit, noffset, FIT_DATA_PROP, &len);
-    if (*data == NULL) {
-        fit_get_debug(fit, noffset, FIT_DATA_PROP, len);
-        *size = 0;
-        return -1;
-    }
+	*data = fdt_getprop(fit, noffset, FIT_DATA_PROP, &len);
+	if (*data == NULL) {
+		fit_get_debug(fit, noffset, FIT_DATA_PROP, len);
+		*size = 0;
+		return -1;
+	}
 
-    *size = len;
-    return 0;
+	*size = len;
+	return 0;
 }
 
 /**
@@ -784,20 +784,20 @@ int fit_image_get_data(const void *fit, int noffset,
  * @data_offset: holds the data-offset property
  *
  * returns:
- *     0, on success
- *     -ENOENT if the property could not be found
+ *	 0, on success
+ *	 -ENOENT if the property could not be found
  */
 int fit_image_get_data_offset(const void *fit, int noffset, int *data_offset)
 {
-    const fdt32_t *val;
+	const fdt32_t *val;
 
-    val = fdt_getprop(fit, noffset, FIT_DATA_OFFSET_PROP, NULL);
-    if (!val)
-        return -ENOENT;
+	val = fdt_getprop(fit, noffset, FIT_DATA_OFFSET_PROP, NULL);
+	if (!val)
+		return -ENOENT;
 
-    *data_offset = fdt32_to_cpu(*val);
+	*data_offset = fdt32_to_cpu(*val);
 
-    return 0;
+	return 0;
 }
 
 /**
@@ -808,21 +808,22 @@ int fit_image_get_data_offset(const void *fit, int noffset, int *data_offset)
  * @data_size: holds the data-size property
  *
  * returns:
- *     0, on success
- *     -ENOENT if the property could not be found
+ *	 0, on success
+ *	 -ENOENT if the property could not be found
  */
 int fit_image_get_data_size(const void *fit, int noffset, int *data_size)
 {
-    const fdt32_t *val;
+	const fdt32_t *val;
 
-    val = fdt_getprop(fit, noffset, FIT_DATA_SIZE_PROP, NULL);
-    if (!val)
-        return -ENOENT;
+	val = fdt_getprop(fit, noffset, FIT_DATA_SIZE_PROP, NULL);
+	if (!val)
+		return -ENOENT;
 
-    *data_size = fdt32_to_cpu(*val);
+	*data_size = fdt32_to_cpu(*val);
 
-    return 0;
+	return 0;
 }
+
 
 /**
  * fit_image_hash_get_algo - get hash algorithm name
@@ -839,15 +840,15 @@ int fit_image_get_data_size(const void *fit, int noffset, int *data_size)
  */
 int fit_image_hash_get_algo(const void *fit, int noffset, char **algo)
 {
-    int len;
+	int len;
 
-    *algo = (char *)fdt_getprop(fit, noffset, FIT_ALGO_PROP, &len);
-    if (*algo == NULL) {
-        fit_get_debug(fit, noffset, FIT_ALGO_PROP, len);
-        return -1;
-    }
+	*algo = (char *)fdt_getprop(fit, noffset, FIT_ALGO_PROP, &len);
+	if (*algo == NULL) {
+		fit_get_debug(fit, noffset, FIT_ALGO_PROP, len);
+		return -1;
+	}
 
-    return 0;
+	return 0;
 }
 
 /**
@@ -866,19 +867,19 @@ int fit_image_hash_get_algo(const void *fit, int noffset, char **algo)
  *     -1, on failure
  */
 int fit_image_hash_get_value(const void *fit, int noffset, uint8_t **value,
-                int *value_len)
+				int *value_len)
 {
-    int len;
+	int len;
 
-    *value = (uint8_t *)fdt_getprop(fit, noffset, FIT_VALUE_PROP, &len);
-    if (*value == NULL) {
-        fit_get_debug(fit, noffset, FIT_VALUE_PROP, len);
-        *value_len = 0;
-        return -1;
-    }
+	*value = (uint8_t *)fdt_getprop(fit, noffset, FIT_VALUE_PROP, &len);
+	if (*value == NULL) {
+		fit_get_debug(fit, noffset, FIT_VALUE_PROP, len);
+		*value_len = 0;
+		return -1;
+	}
 
-    *value_len = len;
-    return 0;
+	*value_len = len;
+	return 0;
 }
 
 /**
@@ -897,21 +898,21 @@ int fit_image_hash_get_value(const void *fit, int noffset, uint8_t **value,
  */
 static int fit_image_hash_get_ignore(const void *fit, int noffset, int *ignore)
 {
-    int len;
-    int *value;
+	int len;
+	int *value;
 
-    value = (int *)fdt_getprop(fit, noffset, FIT_IGNORE_PROP, &len);
-    if (value == NULL || len != sizeof(int))
-        *ignore = 0;
-    else
-        *ignore = *value;
+	value = (int *)fdt_getprop(fit, noffset, FIT_IGNORE_PROP, &len);
+	if (value == NULL || len != sizeof(int))
+		*ignore = 0;
+	else
+		*ignore = *value;
 
-    return 0;
+	return 0;
 }
 
 ulong fit_get_end(const void *fit)
 {
-    return map_to_sysmem((void *)(fit + fdt_totalsize(fit)));
+	return map_to_sysmem((void *)(fit + fdt_totalsize(fit)));
 }
 
 /**
@@ -929,20 +930,20 @@ ulong fit_get_end(const void *fit)
  */
 int fit_set_timestamp(void *fit, int noffset, time_t timestamp)
 {
-    uint32_t t;
-    int ret;
+	uint32_t t;
+	int ret;
 
-    t = cpu_to_uimage(timestamp);
-    ret = fdt_setprop(fit, noffset, FIT_TIMESTAMP_PROP, &t,
-                sizeof(uint32_t));
-    if (ret) {
-        debug("Can't set '%s' property for '%s' node (%s)\n",
-              FIT_TIMESTAMP_PROP, fit_get_name(fit, noffset, NULL),
-              fdt_strerror(ret));
-        return ret == -FDT_ERR_NOSPACE ? -ENOSPC : -1;
-    }
+	t = cpu_to_uimage(timestamp);
+	ret = fdt_setprop(fit, noffset, FIT_TIMESTAMP_PROP, &t,
+				sizeof(uint32_t));
+	if (ret) {
+		debug("Can't set '%s' property for '%s' node (%s)\n",
+		      FIT_TIMESTAMP_PROP, fit_get_name(fit, noffset, NULL),
+		      fdt_strerror(ret));
+		return ret == -FDT_ERR_NOSPACE ? -ENOSPC : -1;
+	}
 
-    return 0;
+	return 0;
 }
 
 /**
@@ -964,77 +965,77 @@ int fit_set_timestamp(void *fit, int noffset, time_t timestamp)
  *    -1, when algo is unsupported
  */
 int calculate_hash(const void *data, int data_len, const char *algo,
-            uint8_t *value, int *value_len)
+			uint8_t *value, int *value_len)
 {
-    if (IMAGE_ENABLE_CRC32 && strcmp(algo, "crc32") == 0) {
-        *((uint32_t *)value) = crc32_wd(0, data, data_len,
-                            CHUNKSZ_CRC32);
-        *((uint32_t *)value) = cpu_to_uimage(*((uint32_t *)value));
-        *value_len = 4;
-    } else if (IMAGE_ENABLE_SHA1 && strcmp(algo, "sha1") == 0) {
-        sha1_csum_wd((unsigned char *)data, data_len,
-                 (unsigned char *)value, CHUNKSZ_SHA1);
-        *value_len = 20;
-    } else if (IMAGE_ENABLE_SHA256 && strcmp(algo, "sha256") == 0) {
-        sha256_csum_wd((unsigned char *)data, data_len,
-                   (unsigned char *)value, CHUNKSZ_SHA256);
-        *value_len = SHA256_SUM_LEN;
-    } else if (IMAGE_ENABLE_MD5 && strcmp(algo, "md5") == 0) {
-        md5_wd((unsigned char *)data, data_len, value, CHUNKSZ_MD5);
-        *value_len = 16;
-    } else {
-        debug("Unsupported hash alogrithm\n");
-        return -1;
-    }
-    return 0;
+	if (IMAGE_ENABLE_CRC32 && strcmp(algo, "crc32") == 0) {
+		*((uint32_t *)value) = crc32_wd(0, data, data_len,
+							CHUNKSZ_CRC32);
+		*((uint32_t *)value) = cpu_to_uimage(*((uint32_t *)value));
+		*value_len = 4;
+	} else if (IMAGE_ENABLE_SHA1 && strcmp(algo, "sha1") == 0) {
+		sha1_csum_wd((unsigned char *)data, data_len,
+			     (unsigned char *)value, CHUNKSZ_SHA1);
+		*value_len = 20;
+	} else if (IMAGE_ENABLE_SHA256 && strcmp(algo, "sha256") == 0) {
+		sha256_csum_wd((unsigned char *)data, data_len,
+			       (unsigned char *)value, CHUNKSZ_SHA256);
+		*value_len = SHA256_SUM_LEN;
+	} else if (IMAGE_ENABLE_MD5 && strcmp(algo, "md5") == 0) {
+		md5_wd((unsigned char *)data, data_len, value, CHUNKSZ_MD5);
+		*value_len = 16;
+	} else {
+		debug("Unsupported hash alogrithm\n");
+		return -1;
+	}
+	return 0;
 }
 
 static int fit_image_check_hash(const void *fit, int noffset, const void *data,
-                size_t size, char **err_msgp)
+				size_t size, char **err_msgp)
 {
-    uint8_t value[FIT_MAX_HASH_LEN];
-    int value_len;
-    char *algo;
-    uint8_t *fit_value;
-    int fit_value_len;
-    int ignore;
+	uint8_t value[FIT_MAX_HASH_LEN];
+	int value_len;
+	char *algo;
+	uint8_t *fit_value;
+	int fit_value_len;
+	int ignore;
 
-    *err_msgp = NULL;
+	*err_msgp = NULL;
 
-    if (fit_image_hash_get_algo(fit, noffset, &algo)) {
-        *err_msgp = "Can't get hash algo property";
-        return -1;
-    }
-    printf("%s", algo);
+	if (fit_image_hash_get_algo(fit, noffset, &algo)) {
+		*err_msgp = "Can't get hash algo property";
+		return -1;
+	}
+	printf("%s", algo);
 
-    if (IMAGE_ENABLE_IGNORE) {
-        fit_image_hash_get_ignore(fit, noffset, &ignore);
-        if (ignore) {
-            printf("-skipped ");
-            return 0;
-        }
-    }
+	if (IMAGE_ENABLE_IGNORE) {
+		fit_image_hash_get_ignore(fit, noffset, &ignore);
+		if (ignore) {
+			printf("-skipped ");
+			return 0;
+		}
+	}
 
-    if (fit_image_hash_get_value(fit, noffset, &fit_value,
-                     &fit_value_len)) {
-        *err_msgp = "Can't get hash value property";
-        return -1;
-    }
+	if (fit_image_hash_get_value(fit, noffset, &fit_value,
+				     &fit_value_len)) {
+		*err_msgp = "Can't get hash value property";
+		return -1;
+	}
 
-    if (calculate_hash(data, size, algo, value, &value_len)) {
-        *err_msgp = "Unsupported hash algorithm";
-        return -1;
-    }
+	if (calculate_hash(data, size, algo, value, &value_len)) {
+		*err_msgp = "Unsupported hash algorithm";
+		return -1;
+	}
 
-    if (value_len != fit_value_len) {
-        *err_msgp = "Bad hash value len";
-        return -1;
-    } else if (memcmp(value, fit_value, value_len) != 0) {
-        *err_msgp = "Bad hash value";
-        return -1;
-    }
+	if (value_len != fit_value_len) {
+		*err_msgp = "Bad hash value len";
+		return -1;
+	} else if (memcmp(value, fit_value, value_len) != 0) {
+		*err_msgp = "Bad hash value";
+		return -1;
+	}
 
-    return 0;
+	return 0;
 }
 
 /**
@@ -1052,73 +1053,73 @@ static int fit_image_check_hash(const void *fit, int noffset, const void *data,
  */
 int fit_image_verify(const void *fit, int image_noffset)
 {
-    const void  *data;
-    size_t      size;
-    int     noffset = 0;
-    char        *err_msg = "";
-    int verify_all = 1;
-    int ret;
+	const void	*data;
+	size_t		size;
+	int		noffset = 0;
+	char		*err_msg = "";
+	int verify_all = 1;
+	int ret;
 
-    /* Get image data and data length */
-    if (fit_image_get_data(fit, image_noffset, &data, &size)) {
-        err_msg = "Can't get image data/size";
-        goto error;
-    }
+	/* Get image data and data length */
+	if (fit_image_get_data(fit, image_noffset, &data, &size)) {
+		err_msg = "Can't get image data/size";
+		goto error;
+	}
 
-    /* Verify all required signatures */
-    if (IMAGE_ENABLE_VERIFY &&
-        fit_image_verify_required_sigs(fit, image_noffset, data, size,
-                       gd_fdt_blob(), &verify_all)) {
-        err_msg = "Unable to verify required signature";
-        goto error;
-    }
+	/* Verify all required signatures */
+	if (IMAGE_ENABLE_VERIFY &&
+	    fit_image_verify_required_sigs(fit, image_noffset, data, size,
+					   gd_fdt_blob(), &verify_all)) {
+		err_msg = "Unable to verify required signature";
+		goto error;
+	}
 
-    /* Process all hash subnodes of the component image node */
-    fdt_for_each_subnode(fit, noffset, image_noffset) {
-        const char *name = fit_get_name(fit, noffset, NULL);
+	/* Process all hash subnodes of the component image node */
+	fdt_for_each_subnode(fit, noffset, image_noffset) {
+		const char *name = fit_get_name(fit, noffset, NULL);
 
-        /*
-         * Check subnode name, must be equal to "hash".
-         * Multiple hash nodes require unique unit node
-         * names, e.g. hash@1, hash@2, etc.
-         */
-        if (!strncmp(name, FIT_HASH_NODENAME,
-                 strlen(FIT_HASH_NODENAME))) {
-            if (fit_image_check_hash(fit, noffset, data, size,
-                         &err_msg))
-                goto error;
-            puts("+ ");
-        } else if (IMAGE_ENABLE_VERIFY && verify_all &&
-                !strncmp(name, FIT_SIG_NODENAME,
-                    strlen(FIT_SIG_NODENAME))) {
-            ret = fit_image_check_sig(fit, noffset, data,
-                            size, -1, &err_msg);
+		/*
+		 * Check subnode name, must be equal to "hash".
+		 * Multiple hash nodes require unique unit node
+		 * names, e.g. hash@1, hash@2, etc.
+		 */
+		if (!strncmp(name, FIT_HASH_NODENAME,
+			     strlen(FIT_HASH_NODENAME))) {
+			if (fit_image_check_hash(fit, noffset, data, size,
+						 &err_msg))
+				goto error;
+			puts("+ ");
+		} else if (IMAGE_ENABLE_VERIFY && verify_all &&
+				!strncmp(name, FIT_SIG_NODENAME,
+					strlen(FIT_SIG_NODENAME))) {
+			ret = fit_image_check_sig(fit, noffset, data,
+							size, -1, &err_msg);
 
-            /*
-             * Show an indication on failure, but do not return
-             * an error. Only keys marked 'required' can cause
-             * an image validation failure. See the call to
-             * fit_image_verify_required_sigs() above.
-             */
-            if (ret)
-                puts("- ");
-            else
-                puts("+ ");
-        }
-    }
+			/*
+			 * Show an indication on failure, but do not return
+			 * an error. Only keys marked 'required' can cause
+			 * an image validation failure. See the call to
+			 * fit_image_verify_required_sigs() above.
+			 */
+			if (ret)
+				puts("- ");
+			else
+				puts("+ ");
+		}
+	}
 
-    if (noffset == -FDT_ERR_TRUNCATED || noffset == -FDT_ERR_BADSTRUCTURE) {
-        err_msg = "Corrupted or truncated tree";
-        goto error;
-    }
+	if (noffset == -FDT_ERR_TRUNCATED || noffset == -FDT_ERR_BADSTRUCTURE) {
+		err_msg = "Corrupted or truncated tree";
+		goto error;
+	}
 
-    return 1;
+	return 1;
 
 error:
-    printf(" error!\n%s for '%s' hash node in '%s' image node\n",
-           err_msg, fit_get_name(fit, noffset, NULL),
-           fit_get_name(fit, image_noffset, NULL));
-    return 0;
+	printf(" error!\n%s for '%s' hash node in '%s' image node\n",
+	       err_msg, fit_get_name(fit, noffset, NULL),
+	       fit_get_name(fit, image_noffset, NULL));
+	return 0;
 }
 
 /**
@@ -1134,41 +1135,41 @@ error:
  */
 int fit_all_image_verify(const void *fit)
 {
-    int images_noffset;
-    int noffset;
-    int ndepth;
-    int count;
+	int images_noffset;
+	int noffset;
+	int ndepth;
+	int count;
 
-    /* Find images parent node offset */
-    images_noffset = fdt_path_offset(fit, FIT_IMAGES_PATH);
-    if (images_noffset < 0) {
-        printf("Can't find images parent node '%s' (%s)\n",
-               FIT_IMAGES_PATH, fdt_strerror(images_noffset));
-        return 0;
-    }
+	/* Find images parent node offset */
+	images_noffset = fdt_path_offset(fit, FIT_IMAGES_PATH);
+	if (images_noffset < 0) {
+		printf("Can't find images parent node '%s' (%s)\n",
+		       FIT_IMAGES_PATH, fdt_strerror(images_noffset));
+		return 0;
+	}
 
-    /* Process all image subnodes, check hashes for each */
-    printf("## Checking hash(es) for FIT Image at %08lx ...\n",
-           (ulong)fit);
-    for (ndepth = 0, count = 0,
-         noffset = fdt_next_node(fit, images_noffset, &ndepth);
-            (noffset >= 0) && (ndepth > 0);
-            noffset = fdt_next_node(fit, noffset, &ndepth)) {
-        if (ndepth == 1) {
-            /*
-             * Direct child node of the images parent node,
-             * i.e. component image node.
-             */
-            printf("   Hash(es) for Image %u (%s): ", count,
-                   fit_get_name(fit, noffset, NULL));
-            count++;
+	/* Process all image subnodes, check hashes for each */
+	printf("## Checking hash(es) for FIT Image at %08lx ...\n",
+	       (ulong)fit);
+	for (ndepth = 0, count = 0,
+	     noffset = fdt_next_node(fit, images_noffset, &ndepth);
+			(noffset >= 0) && (ndepth > 0);
+			noffset = fdt_next_node(fit, noffset, &ndepth)) {
+		if (ndepth == 1) {
+			/*
+			 * Direct child node of the images parent node,
+			 * i.e. component image node.
+			 */
+			printf("   Hash(es) for Image %u (%s): ", count,
+			       fit_get_name(fit, noffset, NULL));
+			count++;
 
-            if (!fit_image_verify(fit, noffset))
-                return 0;
-            printf("\n");
-        }
-    }
-    return 1;
+			if (!fit_image_verify(fit, noffset))
+				return 0;
+			printf("\n");
+		}
+	}
+	return 1;
 }
 
 /**
@@ -1186,11 +1187,11 @@ int fit_all_image_verify(const void *fit)
  */
 int fit_image_check_os(const void *fit, int noffset, uint8_t os)
 {
-    uint8_t image_os;
+	uint8_t image_os;
 
-    if (fit_image_get_os(fit, noffset, &image_os))
-        return 0;
-    return (os == image_os);
+	if (fit_image_get_os(fit, noffset, &image_os))
+		return 0;
+	return (os == image_os);
 }
 
 /**
@@ -1208,12 +1209,12 @@ int fit_image_check_os(const void *fit, int noffset, uint8_t os)
  */
 int fit_image_check_arch(const void *fit, int noffset, uint8_t arch)
 {
-    uint8_t image_arch;
+	uint8_t image_arch;
 
-    if (fit_image_get_arch(fit, noffset, &image_arch))
-        return 0;
-    return (arch == image_arch) ||
-        (arch == IH_ARCH_I386 && image_arch == IH_ARCH_X86_64);
+	if (fit_image_get_arch(fit, noffset, &image_arch))
+		return 0;
+	return (arch == image_arch) ||
+		(arch == IH_ARCH_I386 && image_arch == IH_ARCH_X86_64);
 }
 
 /**
@@ -1231,11 +1232,11 @@ int fit_image_check_arch(const void *fit, int noffset, uint8_t arch)
  */
 int fit_image_check_type(const void *fit, int noffset, uint8_t type)
 {
-    uint8_t image_type;
+	uint8_t image_type;
 
-    if (fit_image_get_type(fit, noffset, &image_type))
-        return 0;
-    return (type == image_type);
+	if (fit_image_get_type(fit, noffset, &image_type))
+		return 0;
+	return (type == image_type);
 }
 
 /**
@@ -1254,11 +1255,11 @@ int fit_image_check_type(const void *fit, int noffset, uint8_t type)
  */
 int fit_image_check_comp(const void *fit, int noffset, uint8_t comp)
 {
-    uint8_t image_comp;
+	uint8_t image_comp;
 
-    if (fit_image_get_comp(fit, noffset, &image_comp))
-        return 0;
-    return (comp == image_comp);
+	if (fit_image_get_comp(fit, noffset, &image_comp))
+		return 0;
+	return (comp == image_comp);
 }
 
 /**
@@ -1274,27 +1275,27 @@ int fit_image_check_comp(const void *fit, int noffset, uint8_t comp)
  */
 int fit_check_format(const void *fit)
 {
-    /* mandatory / node 'description' property */
-    if (fdt_getprop(fit, 0, FIT_DESC_PROP, NULL) == NULL) {
-        debug("Wrong FIT format: no description\n");
-        return 0;
-    }
+	/* mandatory / node 'description' property */
+	if (fdt_getprop(fit, 0, FIT_DESC_PROP, NULL) == NULL) {
+		debug("Wrong FIT format: no description\n");
+		return 0;
+	}
 
-    if (IMAGE_ENABLE_TIMESTAMP) {
-        /* mandatory / node 'timestamp' property */
-        if (fdt_getprop(fit, 0, FIT_TIMESTAMP_PROP, NULL) == NULL) {
-            debug("Wrong FIT format: no timestamp\n");
-            return 0;
-        }
-    }
+	if (IMAGE_ENABLE_TIMESTAMP) {
+		/* mandatory / node 'timestamp' property */
+		if (fdt_getprop(fit, 0, FIT_TIMESTAMP_PROP, NULL) == NULL) {
+			debug("Wrong FIT format: no timestamp\n");
+			return 0;
+		}
+	}
 
-    /* mandatory subimages parent '/images' node */
-    if (fdt_path_offset(fit, FIT_IMAGES_PATH) < 0) {
-        debug("Wrong FIT format: no images parent node\n");
-        return 0;
-    }
+	/* mandatory subimages parent '/images' node */
+	if (fdt_path_offset(fit, FIT_IMAGES_PATH) < 0) {
+		debug("Wrong FIT format: no images parent node\n");
+		return 0;
+	}
 
-    return 1;
+	return 1;
 }
 
 
@@ -1339,89 +1340,89 @@ int fit_check_format(const void *fit)
  */
 int fit_conf_find_compat(const void *fit, const void *fdt)
 {
-    int ndepth = 0;
-    int noffset, confs_noffset, images_noffset;
-    const void *fdt_compat;
-    int fdt_compat_len;
-    int best_match_offset = 0;
-    int best_match_pos = 0;
+	int ndepth = 0;
+	int noffset, confs_noffset, images_noffset;
+	const void *fdt_compat;
+	int fdt_compat_len;
+	int best_match_offset = 0;
+	int best_match_pos = 0;
 
-    confs_noffset = fdt_path_offset(fit, FIT_CONFS_PATH);
-    images_noffset = fdt_path_offset(fit, FIT_IMAGES_PATH);
-    if (confs_noffset < 0 || images_noffset < 0) {
-        debug("Can't find configurations or images nodes.\n");
-        return -1;
-    }
+	confs_noffset = fdt_path_offset(fit, FIT_CONFS_PATH);
+	images_noffset = fdt_path_offset(fit, FIT_IMAGES_PATH);
+	if (confs_noffset < 0 || images_noffset < 0) {
+		debug("Can't find configurations or images nodes.\n");
+		return -1;
+	}
 
-    fdt_compat = fdt_getprop(fdt, 0, "compatible", &fdt_compat_len);
-    if (!fdt_compat) {
-        debug("Fdt for comparison has no \"compatible\" property.\n");
-        return -1;
-    }
+	fdt_compat = fdt_getprop(fdt, 0, "compatible", &fdt_compat_len);
+	if (!fdt_compat) {
+		debug("Fdt for comparison has no \"compatible\" property.\n");
+		return -1;
+	}
 
-    /*
-     * Loop over the configurations in the FIT image.
-     */
-    for (noffset = fdt_next_node(fit, confs_noffset, &ndepth);
-            (noffset >= 0) && (ndepth > 0);
-            noffset = fdt_next_node(fit, noffset, &ndepth)) {
-        const void *kfdt;
-        const char *kfdt_name;
-        int kfdt_noffset;
-        const char *cur_fdt_compat;
-        int len;
-        size_t size;
-        int i;
+	/*
+	 * Loop over the configurations in the FIT image.
+	 */
+	for (noffset = fdt_next_node(fit, confs_noffset, &ndepth);
+			(noffset >= 0) && (ndepth > 0);
+			noffset = fdt_next_node(fit, noffset, &ndepth)) {
+		const void *kfdt;
+		const char *kfdt_name;
+		int kfdt_noffset;
+		const char *cur_fdt_compat;
+		int len;
+		size_t size;
+		int i;
 
-        if (ndepth > 1)
-            continue;
+		if (ndepth > 1)
+			continue;
 
-        kfdt_name = fdt_getprop(fit, noffset, "fdt", &len);
-        if (!kfdt_name) {
-            debug("No fdt property found.\n");
-            continue;
-        }
-        kfdt_noffset = fdt_subnode_offset(fit, images_noffset,
-                          kfdt_name);
-        if (kfdt_noffset < 0) {
-            debug("No image node named \"%s\" found.\n",
-                  kfdt_name);
-            continue;
-        }
-        /*
-         * Get a pointer to this configuration's fdt.
-         */
-        if (fit_image_get_data(fit, kfdt_noffset, &kfdt, &size)) {
-            debug("Failed to get fdt \"%s\".\n", kfdt_name);
-            continue;
-        }
+		kfdt_name = fdt_getprop(fit, noffset, "fdt", &len);
+		if (!kfdt_name) {
+			debug("No fdt property found.\n");
+			continue;
+		}
+		kfdt_noffset = fdt_subnode_offset(fit, images_noffset,
+						  kfdt_name);
+		if (kfdt_noffset < 0) {
+			debug("No image node named \"%s\" found.\n",
+			      kfdt_name);
+			continue;
+		}
+		/*
+		 * Get a pointer to this configuration's fdt.
+		 */
+		if (fit_image_get_data(fit, kfdt_noffset, &kfdt, &size)) {
+			debug("Failed to get fdt \"%s\".\n", kfdt_name);
+			continue;
+		}
 
-        len = fdt_compat_len;
-        cur_fdt_compat = fdt_compat;
-        /*
-         * Look for a match for each U-Boot compatibility string in
-         * turn in this configuration's fdt.
-         */
-        for (i = 0; len > 0 &&
-             (!best_match_offset || best_match_pos > i); i++) {
-            int cur_len = strlen(cur_fdt_compat) + 1;
+		len = fdt_compat_len;
+		cur_fdt_compat = fdt_compat;
+		/*
+		 * Look for a match for each U-Boot compatibility string in
+		 * turn in this configuration's fdt.
+		 */
+		for (i = 0; len > 0 &&
+		     (!best_match_offset || best_match_pos > i); i++) {
+			int cur_len = strlen(cur_fdt_compat) + 1;
 
-            if (!fdt_node_check_compatible(kfdt, 0,
-                               cur_fdt_compat)) {
-                best_match_offset = noffset;
-                best_match_pos = i;
-                break;
-            }
-            len -= cur_len;
-            cur_fdt_compat += cur_len;
-        }
-    }
-    if (!best_match_offset) {
-        debug("No match found.\n");
-        return -1;
-    }
+			if (!fdt_node_check_compatible(kfdt, 0,
+						       cur_fdt_compat)) {
+				best_match_offset = noffset;
+				best_match_pos = i;
+				break;
+			}
+			len -= cur_len;
+			cur_fdt_compat += cur_len;
+		}
+	}
+	if (!best_match_offset) {
+		debug("No match found.\n");
+		return -1;
+	}
 
-    return best_match_offset;
+	return best_match_offset;
 }
 
 /**
@@ -1444,50 +1445,50 @@ int fit_conf_find_compat(const void *fit, const void *fdt)
  */
 int fit_conf_get_node(const void *fit, const char *conf_uname)
 {
-    int noffset, confs_noffset;
-    int len;
+	int noffset, confs_noffset;
+	int len;
 
-    confs_noffset = fdt_path_offset(fit, FIT_CONFS_PATH);
-    if (confs_noffset < 0) {
-        debug("Can't find configurations parent node '%s' (%s)\n",
-              FIT_CONFS_PATH, fdt_strerror(confs_noffset));
-        return confs_noffset;
-    }
+	confs_noffset = fdt_path_offset(fit, FIT_CONFS_PATH);
+	if (confs_noffset < 0) {
+		debug("Can't find configurations parent node '%s' (%s)\n",
+		      FIT_CONFS_PATH, fdt_strerror(confs_noffset));
+		return confs_noffset;
+	}
 
-    if (conf_uname == NULL) {
-        /* get configuration unit name from the default property */
-        debug("No configuration specified, trying default...\n");
-        conf_uname = (char *)fdt_getprop(fit, confs_noffset,
-                         FIT_DEFAULT_PROP, &len);
-        if (conf_uname == NULL) {
-            fit_get_debug(fit, confs_noffset, FIT_DEFAULT_PROP,
-                      len);
-            return len;
-        }
-        debug("Found default configuration: '%s'\n", conf_uname);
-    }
+	if (conf_uname == NULL) {
+		/* get configuration unit name from the default property */
+		debug("No configuration specified, trying default...\n");
+		conf_uname = (char *)fdt_getprop(fit, confs_noffset,
+						 FIT_DEFAULT_PROP, &len);
+		if (conf_uname == NULL) {
+			fit_get_debug(fit, confs_noffset, FIT_DEFAULT_PROP,
+				      len);
+			return len;
+		}
+		debug("Found default configuration: '%s'\n", conf_uname);
+	}
 
-    noffset = fdt_subnode_offset(fit, confs_noffset, conf_uname);
-    if (noffset < 0) {
-        debug("Can't get node offset for configuration unit name: '%s' (%s)\n",
-              conf_uname, fdt_strerror(noffset));
-    }
+	noffset = fdt_subnode_offset(fit, confs_noffset, conf_uname);
+	if (noffset < 0) {
+		debug("Can't get node offset for configuration unit name: '%s' (%s)\n",
+		      conf_uname, fdt_strerror(noffset));
+	}
 
-    return noffset;
+	return noffset;
 }
 
 int fit_conf_get_prop_node(const void *fit, int noffset,
-        const char *prop_name)
+		const char *prop_name)
 {
-    char *uname;
-    int len;
+	char *uname;
+	int len;
 
-    /* get kernel image unit name from configuration kernel property */
-    uname = (char *)fdt_getprop(fit, noffset, prop_name, &len);
-    if (uname == NULL)
-        return len;
+	/* get kernel image unit name from configuration kernel property */
+	uname = (char *)fdt_getprop(fit, noffset, prop_name, &len);
+	if (uname == NULL)
+		return len;
 
-    return fit_image_get_node(fit, uname);
+	return fit_image_get_node(fit, uname);
 }
 
 /**
@@ -1504,120 +1505,120 @@ int fit_conf_get_prop_node(const void *fit, int noffset,
  */
 void fit_conf_print(const void *fit, int noffset, const char *p)
 {
-    char *desc;
-    char *uname;
-    int ret;
-    int loadables_index;
+	char *desc;
+	char *uname;
+	int ret;
+	int loadables_index;
 
-    /* Mandatory properties */
-    ret = fit_get_desc(fit, noffset, &desc);
-    printf("%s  Description:  ", p);
-    if (ret)
-        printf("unavailable\n");
-    else
-        printf("%s\n", desc);
+	/* Mandatory properties */
+	ret = fit_get_desc(fit, noffset, &desc);
+	printf("%s  Description:  ", p);
+	if (ret)
+		printf("unavailable\n");
+	else
+		printf("%s\n", desc);
 
-    uname = (char *)fdt_getprop(fit, noffset, FIT_KERNEL_PROP, NULL);
-    printf("%s  Kernel:       ", p);
-    if (uname == NULL)
-        printf("unavailable\n");
-    else
-        printf("%s\n", uname);
+	uname = (char *)fdt_getprop(fit, noffset, FIT_KERNEL_PROP, NULL);
+	printf("%s  Kernel:       ", p);
+	if (uname == NULL)
+		printf("unavailable\n");
+	else
+		printf("%s\n", uname);
 
-    /* Optional properties */
-    uname = (char *)fdt_getprop(fit, noffset, FIT_RAMDISK_PROP, NULL);
-    if (uname)
-        printf("%s  Init Ramdisk: %s\n", p, uname);
+	/* Optional properties */
+	uname = (char *)fdt_getprop(fit, noffset, FIT_RAMDISK_PROP, NULL);
+	if (uname)
+		printf("%s  Init Ramdisk: %s\n", p, uname);
 
-    uname = (char *)fdt_getprop(fit, noffset, FIT_FDT_PROP, NULL);
-    if (uname)
-        printf("%s  FDT:          %s\n", p, uname);
+	uname = (char *)fdt_getprop(fit, noffset, FIT_FDT_PROP, NULL);
+	if (uname)
+		printf("%s  FDT:          %s\n", p, uname);
 
-    uname = (char *)fdt_getprop(fit, noffset, FIT_FPGA_PROP, NULL);
-    if (uname)
-        printf("%s  FPGA:         %s\n", p, uname);
+	uname = (char *)fdt_getprop(fit, noffset, FIT_FPGA_PROP, NULL);
+	if (uname)
+		printf("%s  FPGA:         %s\n", p, uname);
 
-    /* Print out all of the specified loadables */
-    for (loadables_index = 0;
-         fdt_get_string_index(fit, noffset,
-            FIT_LOADABLE_PROP,
-            loadables_index,
-            (const char **)&uname) == 0;
-         loadables_index++)
-    {
-        if (loadables_index == 0) {
-            printf("%s  Loadables:    ", p);
-        } else {
-            printf("%s                ", p);
-        }
-        printf("%s\n", uname);
-    }
+	/* Print out all of the specified loadables */
+	for (loadables_index = 0;
+	     fdt_get_string_index(fit, noffset,
+			FIT_LOADABLE_PROP,
+			loadables_index,
+			(const char **)&uname) == 0;
+	     loadables_index++)
+	{
+		if (loadables_index == 0) {
+			printf("%s  Loadables:    ", p);
+		} else {
+			printf("%s                ", p);
+		}
+		printf("%s\n", uname);
+	}
 }
 
 static int fit_image_select(const void *fit, int rd_noffset, int verify)
 {
 #if !defined(USE_HOSTCC) && defined(CONFIG_FIT_IMAGE_POST_PROCESS)
-    const void *data;
-    size_t size;
-    int ret;
+	const void *data;
+	size_t size;
+	int ret;
 #endif
 
-    fit_image_print(fit, rd_noffset, "   ");
+	fit_image_print(fit, rd_noffset, "   ");
 
-    if (verify) {
-        puts("   Verifying Hash Integrity ... ");
-        if (!fit_image_verify(fit, rd_noffset)) {
-            puts("Bad Data Hash\n");
-            return -EACCES;
-        }
-        puts("OK\n");
-    }
+	if (verify) {
+		puts("   Verifying Hash Integrity ... ");
+		if (!fit_image_verify(fit, rd_noffset)) {
+			puts("Bad Data Hash\n");
+			return -EACCES;
+		}
+		puts("OK\n");
+	}
 
 #if !defined(USE_HOSTCC) && defined(CONFIG_FIT_IMAGE_POST_PROCESS)
-    ret = fit_image_get_data(fit, rd_noffset, &data, &size);
-    if (ret)
-        return ret;
+	ret = fit_image_get_data(fit, rd_noffset, &data, &size);
+	if (ret)
+		return ret;
 
-    /* perform any post-processing on the image data */
-    board_fit_image_post_process((void **)&data, &size);
+	/* perform any post-processing on the image data */
+	board_fit_image_post_process((void **)&data, &size);
 
-    /*
-     * update U-Boot's understanding of the "data" property start address
-     * and size according to the performed post-processing
-     */
-    ret = fdt_setprop((void *)fit, rd_noffset, FIT_DATA_PROP, data, size);
-    if (ret)
-        return ret;
+	/*
+	 * update U-Boot's understanding of the "data" property start address
+	 * and size according to the performed post-processing
+	 */
+	ret = fdt_setprop((void *)fit, rd_noffset, FIT_DATA_PROP, data, size);
+	if (ret)
+		return ret;
 #endif
 
-    return 0;
+	return 0;
 }
 
 int fit_get_node_from_config(bootm_headers_t *images, const char *prop_name,
-            ulong addr)
+			ulong addr)
 {
-    int cfg_noffset;
-    void *fit_hdr;
-    int noffset;
+	int cfg_noffset;
+	void *fit_hdr;
+	int noffset;
 
-    debug("*  %s: using config '%s' from image at 0x%08lx\n",
-          prop_name, images->fit_uname_cfg, addr);
+	debug("*  %s: using config '%s' from image at 0x%08lx\n",
+	      prop_name, images->fit_uname_cfg, addr);
 
-    /* Check whether configuration has this property defined */
-    fit_hdr = map_sysmem(addr, 0);
-    cfg_noffset = fit_conf_get_node(fit_hdr, images->fit_uname_cfg);
-    if (cfg_noffset < 0) {
-        debug("*  %s: no such config\n", prop_name);
-        return -EINVAL;
-    }
+	/* Check whether configuration has this property defined */
+	fit_hdr = map_sysmem(addr, 0);
+	cfg_noffset = fit_conf_get_node(fit_hdr, images->fit_uname_cfg);
+	if (cfg_noffset < 0) {
+		debug("*  %s: no such config\n", prop_name);
+		return -EINVAL;
+	}
 
-    noffset = fit_conf_get_prop_node(fit_hdr, cfg_noffset, prop_name);
-    if (noffset < 0) {
-        debug("*  %s: no '%s' in config\n", prop_name, prop_name);
-        return -ENOENT;
-    }
+	noffset = fit_conf_get_prop_node(fit_hdr, cfg_noffset, prop_name);
+	if (noffset < 0) {
+		debug("*  %s: no '%s' in config\n", prop_name, prop_name);
+		return -ENOENT;
+	}
 
-    return noffset;
+	return noffset;
 }
 
 /**
@@ -1628,251 +1629,251 @@ int fit_get_node_from_config(bootm_headers_t *images, const char *prop_name,
  */
 static const char *fit_get_image_type_property(int type)
 {
-    /*
-     * This is sort-of available in the uimage_type[] table in image.c
-     * but we don't have access to the short name, and "fdt" is different
-     * anyway. So let's just keep it here.
-     */
-    switch (type) {
-    case IH_TYPE_FLATDT:
-        return FIT_FDT_PROP;
-    case IH_TYPE_KERNEL:
-        return FIT_KERNEL_PROP;
-    case IH_TYPE_RAMDISK:
-        return FIT_RAMDISK_PROP;
-    case IH_TYPE_X86_SETUP:
-        return FIT_SETUP_PROP;
-    case IH_TYPE_LOADABLE:
-        return FIT_LOADABLE_PROP;
-    case IH_TYPE_FPGA:
-        return FIT_FPGA_PROP;
-    }
+	/*
+	 * This is sort-of available in the uimage_type[] table in image.c
+	 * but we don't have access to the short name, and "fdt" is different
+	 * anyway. So let's just keep it here.
+	 */
+	switch (type) {
+	case IH_TYPE_FLATDT:
+		return FIT_FDT_PROP;
+	case IH_TYPE_KERNEL:
+		return FIT_KERNEL_PROP;
+	case IH_TYPE_RAMDISK:
+		return FIT_RAMDISK_PROP;
+	case IH_TYPE_X86_SETUP:
+		return FIT_SETUP_PROP;
+	case IH_TYPE_LOADABLE:
+		return FIT_LOADABLE_PROP;
+	case IH_TYPE_FPGA:
+		return FIT_FPGA_PROP;
+	}
 
-    return "unknown";
+	return "unknown";
 }
 
 int fit_image_load(bootm_headers_t *images, ulong addr,
-           const char **fit_unamep, const char **fit_uname_configp,
-           int arch, int image_type, int bootstage_id,
-           enum fit_load_op load_op, ulong *datap, ulong *lenp)
+		   const char **fit_unamep, const char **fit_uname_configp,
+		   int arch, int image_type, int bootstage_id,
+		   enum fit_load_op load_op, ulong *datap, ulong *lenp)
 {
-    int cfg_noffset, noffset;
-    const char *fit_uname;
-    const char *fit_uname_config;
-    const void *fit;
-    const void *buf;
-    size_t size;
-    int type_ok, os_ok;
-    ulong load, data, len;
-    uint8_t os;
-    const char *prop_name;
-    int ret;
+	int cfg_noffset, noffset;
+	const char *fit_uname;
+	const char *fit_uname_config;
+	const void *fit;
+	const void *buf;
+	size_t size;
+	int type_ok, os_ok;
+	ulong load, data, len;
+	uint8_t os;
+	const char *prop_name;
+	int ret;
 
-    fit = map_sysmem(addr, 0);
-    fit_uname = fit_unamep ? *fit_unamep : NULL;
-    fit_uname_config = fit_uname_configp ? *fit_uname_configp : NULL;
-    prop_name = fit_get_image_type_property(image_type);
-    printf("## Loading %s from FIT Image at %08lx ...\n", prop_name, addr);
+	fit = map_sysmem(addr, 0);
+	fit_uname = fit_unamep ? *fit_unamep : NULL;
+	fit_uname_config = fit_uname_configp ? *fit_uname_configp : NULL;
+	prop_name = fit_get_image_type_property(image_type);
+	printf("## Loading %s from FIT Image at %08lx ...\n", prop_name, addr);
 
-    bootstage_mark(bootstage_id + BOOTSTAGE_SUB_FORMAT);
-    if (!fit_check_format(fit)) {
-        printf("Bad FIT %s image format!\n", prop_name);
-        bootstage_error(bootstage_id + BOOTSTAGE_SUB_FORMAT);
-        return -ENOEXEC;
-    }
-    bootstage_mark(bootstage_id + BOOTSTAGE_SUB_FORMAT_OK);
-    if (fit_uname) {
-        /* get FIT component image node offset */
-        bootstage_mark(bootstage_id + BOOTSTAGE_SUB_UNIT_NAME);
-        noffset = fit_image_get_node(fit, fit_uname);
-    } else {
-        /*
-         * no image node unit name, try to get config
-         * node first. If config unit node name is NULL
-         * fit_conf_get_node() will try to find default config node
-         */
-        bootstage_mark(bootstage_id + BOOTSTAGE_SUB_NO_UNIT_NAME);
-        if (IMAGE_ENABLE_BEST_MATCH && !fit_uname_config) {
-            cfg_noffset = fit_conf_find_compat(fit, gd_fdt_blob());
-        } else {
-            cfg_noffset = fit_conf_get_node(fit,
-                            fit_uname_config);
-        }
-        if (cfg_noffset < 0) {
-            puts("Could not find configuration node\n");
-            bootstage_error(bootstage_id +
-                    BOOTSTAGE_SUB_NO_UNIT_NAME);
-            return -ENOENT;
-        }
-        fit_uname_config = fdt_get_name(fit, cfg_noffset, NULL);
-        printf("   Using '%s' configuration\n", fit_uname_config);
-        if (image_type == IH_TYPE_KERNEL) {
-            /* Remember (and possibly verify) this config */
-            images->fit_uname_cfg = fit_uname_config;
-            if (IMAGE_ENABLE_VERIFY && images->verify) {
-                puts("   Verifying Hash Integrity ... ");
-                if (fit_config_verify(fit, cfg_noffset)) {
-                    puts("Bad Data Hash\n");
-                    bootstage_error(bootstage_id +
-                        BOOTSTAGE_SUB_HASH);
-                    return -EACCES;
-                }
-                puts("OK\n");
-            }
-            bootstage_mark(BOOTSTAGE_ID_FIT_CONFIG);
-        }
+	bootstage_mark(bootstage_id + BOOTSTAGE_SUB_FORMAT);
+	if (!fit_check_format(fit)) {
+		printf("Bad FIT %s image format!\n", prop_name);
+		bootstage_error(bootstage_id + BOOTSTAGE_SUB_FORMAT);
+		return -ENOEXEC;
+	}
+	bootstage_mark(bootstage_id + BOOTSTAGE_SUB_FORMAT_OK);
+	if (fit_uname) {
+		/* get FIT component image node offset */
+		bootstage_mark(bootstage_id + BOOTSTAGE_SUB_UNIT_NAME);
+		noffset = fit_image_get_node(fit, fit_uname);
+	} else {
+		/*
+		 * no image node unit name, try to get config
+		 * node first. If config unit node name is NULL
+		 * fit_conf_get_node() will try to find default config node
+		 */
+		bootstage_mark(bootstage_id + BOOTSTAGE_SUB_NO_UNIT_NAME);
+		if (IMAGE_ENABLE_BEST_MATCH && !fit_uname_config) {
+			cfg_noffset = fit_conf_find_compat(fit, gd_fdt_blob());
+		} else {
+			cfg_noffset = fit_conf_get_node(fit,
+							fit_uname_config);
+		}
+		if (cfg_noffset < 0) {
+			puts("Could not find configuration node\n");
+			bootstage_error(bootstage_id +
+					BOOTSTAGE_SUB_NO_UNIT_NAME);
+			return -ENOENT;
+		}
+		fit_uname_config = fdt_get_name(fit, cfg_noffset, NULL);
+		printf("   Using '%s' configuration\n", fit_uname_config);
+		if (image_type == IH_TYPE_KERNEL) {
+			/* Remember (and possibly verify) this config */
+			images->fit_uname_cfg = fit_uname_config;
+			if (IMAGE_ENABLE_VERIFY && images->verify) {
+				puts("   Verifying Hash Integrity ... ");
+				if (fit_config_verify(fit, cfg_noffset)) {
+					puts("Bad Data Hash\n");
+					bootstage_error(bootstage_id +
+						BOOTSTAGE_SUB_HASH);
+					return -EACCES;
+				}
+				puts("OK\n");
+			}
+			bootstage_mark(BOOTSTAGE_ID_FIT_CONFIG);
+		}
 
-        noffset = fit_conf_get_prop_node(fit, cfg_noffset,
-                         prop_name);
-        fit_uname = fit_get_name(fit, noffset, NULL);
-    }
-    if (noffset < 0) {
-        puts("Could not find subimage node\n");
-        bootstage_error(bootstage_id + BOOTSTAGE_SUB_SUBNODE);
-        return -ENOENT;
-    }
+		noffset = fit_conf_get_prop_node(fit, cfg_noffset,
+						 prop_name);
+		fit_uname = fit_get_name(fit, noffset, NULL);
+	}
+	if (noffset < 0) {
+		puts("Could not find subimage node\n");
+		bootstage_error(bootstage_id + BOOTSTAGE_SUB_SUBNODE);
+		return -ENOENT;
+	}
 
-    printf("   Trying '%s' %s subimage\n", fit_uname, prop_name);
+	printf("   Trying '%s' %s subimage\n", fit_uname, prop_name);
 
-    ret = fit_image_select(fit, noffset, images->verify);
-    if (ret) {
-        bootstage_error(bootstage_id + BOOTSTAGE_SUB_HASH);
-        return ret;
-    }
+	ret = fit_image_select(fit, noffset, images->verify);
+	if (ret) {
+		bootstage_error(bootstage_id + BOOTSTAGE_SUB_HASH);
+		return ret;
+	}
 
-    bootstage_mark(bootstage_id + BOOTSTAGE_SUB_CHECK_ARCH);
+	bootstage_mark(bootstage_id + BOOTSTAGE_SUB_CHECK_ARCH);
 #if !defined(USE_HOSTCC) && !defined(CONFIG_SANDBOX)
-    if (!fit_image_check_target_arch(fit, noffset)) {
-        puts("Unsupported Architecture\n");
-        bootstage_error(bootstage_id + BOOTSTAGE_SUB_CHECK_ARCH);
-        return -ENOEXEC;
-    }
+	if (!fit_image_check_target_arch(fit, noffset)) {
+		puts("Unsupported Architecture\n");
+		bootstage_error(bootstage_id + BOOTSTAGE_SUB_CHECK_ARCH);
+		return -ENOEXEC;
+	}
 #endif
-    if (image_type == IH_TYPE_FLATDT &&
-        !fit_image_check_comp(fit, noffset, IH_COMP_NONE)) {
-        puts("FDT image is compressed");
-        return -EPROTONOSUPPORT;
-    }
+	if (image_type == IH_TYPE_FLATDT &&
+	    !fit_image_check_comp(fit, noffset, IH_COMP_NONE)) {
+		puts("FDT image is compressed");
+		return -EPROTONOSUPPORT;
+	}
 
-    bootstage_mark(bootstage_id + BOOTSTAGE_SUB_CHECK_ALL);
-    type_ok = fit_image_check_type(fit, noffset, image_type) ||
-          fit_image_check_type(fit, noffset, IH_TYPE_FIRMWARE) ||
-          (image_type == IH_TYPE_KERNEL &&
-           fit_image_check_type(fit, noffset, IH_TYPE_KERNEL_NOLOAD));
+	bootstage_mark(bootstage_id + BOOTSTAGE_SUB_CHECK_ALL);
+	type_ok = fit_image_check_type(fit, noffset, image_type) ||
+		  fit_image_check_type(fit, noffset, IH_TYPE_FIRMWARE) ||
+		  (image_type == IH_TYPE_KERNEL &&
+		   fit_image_check_type(fit, noffset, IH_TYPE_KERNEL_NOLOAD));
 
-    os_ok = image_type == IH_TYPE_FLATDT ||
-        image_type == IH_TYPE_FPGA ||
-        fit_image_check_os(fit, noffset, IH_OS_LINUX) ||
-        fit_image_check_os(fit, noffset, IH_OS_U_BOOT) ||
-        fit_image_check_os(fit, noffset, IH_OS_OPENRTOS);
+	os_ok = image_type == IH_TYPE_FLATDT ||
+		image_type == IH_TYPE_FPGA ||
+		fit_image_check_os(fit, noffset, IH_OS_LINUX) ||
+		fit_image_check_os(fit, noffset, IH_OS_U_BOOT) ||
+		fit_image_check_os(fit, noffset, IH_OS_OPENRTOS);
 
-    /*
-     * If either of the checks fail, we should report an error, but
-     * if the image type is coming from the "loadables" field, we
-     * don't care what it is
-     */
-    if ((!type_ok || !os_ok) && image_type != IH_TYPE_LOADABLE) {
-        fit_image_get_os(fit, noffset, &os);
-        printf("No %s %s %s Image\n",
-               genimg_get_os_name(os),
-               genimg_get_arch_name(arch),
-               genimg_get_type_name(image_type));
-        bootstage_error(bootstage_id + BOOTSTAGE_SUB_CHECK_ALL);
-        return -EIO;
-    }
+	/*
+	 * If either of the checks fail, we should report an error, but
+	 * if the image type is coming from the "loadables" field, we
+	 * don't care what it is
+	 */
+	if ((!type_ok || !os_ok) && image_type != IH_TYPE_LOADABLE) {
+		fit_image_get_os(fit, noffset, &os);
+		printf("No %s %s %s Image\n",
+		       genimg_get_os_name(os),
+		       genimg_get_arch_name(arch),
+		       genimg_get_type_name(image_type));
+		bootstage_error(bootstage_id + BOOTSTAGE_SUB_CHECK_ALL);
+		return -EIO;
+	}
 
-    bootstage_mark(bootstage_id + BOOTSTAGE_SUB_CHECK_ALL_OK);
+	bootstage_mark(bootstage_id + BOOTSTAGE_SUB_CHECK_ALL_OK);
 
-    /* get image data address and length */
-    if (fit_image_get_data(fit, noffset, &buf, &size)) {
-        printf("Could not find %s subimage data!\n", prop_name);
-        bootstage_error(bootstage_id + BOOTSTAGE_SUB_GET_DATA);
-        return -ENOENT;
-    }
-    len = (ulong)size;
+	/* get image data address and length */
+	if (fit_image_get_data(fit, noffset, &buf, &size)) {
+		printf("Could not find %s subimage data!\n", prop_name);
+		bootstage_error(bootstage_id + BOOTSTAGE_SUB_GET_DATA);
+		return -ENOENT;
+	}
+	len = (ulong)size;
 
-    /* verify that image data is a proper FDT blob */
-    if (image_type == IH_TYPE_FLATDT && fdt_check_header(buf)) {
-        puts("Subimage data is not a FDT");
-        return -ENOEXEC;
-    }
+	/* verify that image data is a proper FDT blob */
+	if (image_type == IH_TYPE_FLATDT && fdt_check_header(buf)) {
+		puts("Subimage data is not a FDT");
+		return -ENOEXEC;
+	}
 
-    bootstage_mark(bootstage_id + BOOTSTAGE_SUB_GET_DATA_OK);
+	bootstage_mark(bootstage_id + BOOTSTAGE_SUB_GET_DATA_OK);
 
-    /*
-     * Work-around for eldk-4.2 which gives this warning if we try to
-     * cast in the unmap_sysmem() call:
-     * warning: initialization discards qualifiers from pointer target type
-     */
-    {
-        void *vbuf = (void *)buf;
+	/*
+	 * Work-around for eldk-4.2 which gives this warning if we try to
+	 * cast in the unmap_sysmem() call:
+	 * warning: initialization discards qualifiers from pointer target type
+	 */
+	{
+		void *vbuf = (void *)buf;
 
-        data = map_to_sysmem(vbuf);
-    }
+		data = map_to_sysmem(vbuf);
+	}
 
-    if (load_op == FIT_LOAD_IGNORED) {
-        /* Don't load */
-    } else if (fit_image_get_load(fit, noffset, &load)) {
-        if (load_op == FIT_LOAD_REQUIRED) {
-            printf("Can't get %s subimage load address!\n",
-                   prop_name);
-            bootstage_error(bootstage_id + BOOTSTAGE_SUB_LOAD);
-            return -EBADF;
-        }
-    } else if (load_op != FIT_LOAD_OPTIONAL_NON_ZERO || load) {
-        ulong image_start, image_end;
-        ulong load_end;
-        void *dst;
+	if (load_op == FIT_LOAD_IGNORED) {
+		/* Don't load */
+	} else if (fit_image_get_load(fit, noffset, &load)) {
+		if (load_op == FIT_LOAD_REQUIRED) {
+			printf("Can't get %s subimage load address!\n",
+			       prop_name);
+			bootstage_error(bootstage_id + BOOTSTAGE_SUB_LOAD);
+			return -EBADF;
+		}
+	} else if (load_op != FIT_LOAD_OPTIONAL_NON_ZERO || load) {
+		ulong image_start, image_end;
+		ulong load_end;
+		void *dst;
 
-        /*
-         * move image data to the load address,
-         * make sure we don't overwrite initial image
-         */
-        image_start = addr;
-        image_end = addr + fit_get_size(fit);
+		/*
+		 * move image data to the load address,
+		 * make sure we don't overwrite initial image
+		 */
+		image_start = addr;
+		image_end = addr + fit_get_size(fit);
 
-        load_end = load + len;
-        if (image_type != IH_TYPE_KERNEL &&
-            load < image_end && load_end > image_start) {
-            printf("Error: %s overwritten\n", prop_name);
-            return -EXDEV;
-        }
+		load_end = load + len;
+		if (image_type != IH_TYPE_KERNEL &&
+		    load < image_end && load_end > image_start) {
+			printf("Error: %s overwritten\n", prop_name);
+			return -EXDEV;
+		}
 
-        printf("   Loading %s from 0x%08lx to 0x%08lx\n",
-               prop_name, data, load);
+		printf("   Loading %s from 0x%08lx to 0x%08lx\n",
+		       prop_name, data, load);
 
-        dst = map_sysmem(load, len);
-        memmove(dst, buf, len);
-        data = load;
-    }
-    bootstage_mark(bootstage_id + BOOTSTAGE_SUB_LOAD);
+		dst = map_sysmem(load, len);
+		memmove(dst, buf, len);
+		data = load;
+	}
+	bootstage_mark(bootstage_id + BOOTSTAGE_SUB_LOAD);
 
-    *datap = data;
-    *lenp = len;
-    if (fit_unamep)
-        *fit_unamep = (char *)fit_uname;
-    if (fit_uname_configp)
-        *fit_uname_configp = (char *)fit_uname_config;
+	*datap = data;
+	*lenp = len;
+	if (fit_unamep)
+		*fit_unamep = (char *)fit_uname;
+	if (fit_uname_configp)
+		*fit_uname_configp = (char *)fit_uname_config;
 
-    return noffset;
+	return noffset;
 }
 
 int boot_get_setup_fit(bootm_headers_t *images, uint8_t arch,
-            ulong *setup_start, ulong *setup_len)
+			ulong *setup_start, ulong *setup_len)
 {
-    int noffset;
-    ulong addr;
-    ulong len;
-    int ret;
+	int noffset;
+	ulong addr;
+	ulong len;
+	int ret;
 
-    addr = map_to_sysmem(images->fit_hdr_os);
-    noffset = fit_get_node_from_config(images, FIT_SETUP_PROP, addr);
-    if (noffset < 0)
-        return noffset;
+	addr = map_to_sysmem(images->fit_hdr_os);
+	noffset = fit_get_node_from_config(images, FIT_SETUP_PROP, addr);
+	if (noffset < 0)
+		return noffset;
 
-    ret = fit_image_load(images, addr, NULL, NULL, arch,
-                 IH_TYPE_X86_SETUP, BOOTSTAGE_ID_FIT_SETUP_START,
-                 FIT_LOAD_REQUIRED, setup_start, &len);
+	ret = fit_image_load(images, addr, NULL, NULL, arch,
+			     IH_TYPE_X86_SETUP, BOOTSTAGE_ID_FIT_SETUP_START,
+			     FIT_LOAD_REQUIRED, setup_start, &len);
 
-    return ret;
+	return ret;
 }

--- a/common/spl/spl_ext.c
+++ b/common/spl/spl_ext.c
@@ -42,7 +42,7 @@ int spl_load_image_ext(struct blk_desc *block_dev,
 		puts("spl: ext4fs_open failed\n");
 		goto end;
 	}
-	err = ext4fs_read((char *)header, sizeof(struct image_header), &actlen);
+	err = ext4fs_read((char *)header, 0, sizeof(struct image_header), &actlen);
 	if (err < 0) {
 		puts("spl: ext4fs_read failed\n");
 		goto end;
@@ -54,7 +54,7 @@ int spl_load_image_ext(struct blk_desc *block_dev,
 		goto end;
 	}
 
-	err = ext4fs_read((char *)spl_image.load_addr, filelen, &actlen);
+	err = ext4fs_read((char *)spl_image.load_addr, 0, filelen, &actlen);
 
 end:
 #ifdef CONFIG_SPL_LIBCOMMON_SUPPORT
@@ -96,7 +96,7 @@ int spl_load_image_ext_os(struct blk_desc *block_dev, int partition)
 			puts("spl: ext4fs_open failed\n");
 			goto defaults;
 		}
-		err = ext4fs_read((void *)CONFIG_SYS_SPL_ARGS_ADDR, filelen, &actlen);
+		err = ext4fs_read((void *)CONFIG_SYS_SPL_ARGS_ADDR, 0, filelen, &actlen);
 		if (err < 0) {
 			printf("spl: error reading image %s, err - %d, falling back to default\n",
 			       file, err);
@@ -125,7 +125,7 @@ defaults:
 	if (err < 0)
 		puts("spl: ext4fs_open failed\n");
 
-	err = ext4fs_read((void *)CONFIG_SYS_SPL_ARGS_ADDR, filelen, &actlen);
+	err = ext4fs_read((void *)CONFIG_SYS_SPL_ARGS_ADDR, 0, filelen, &actlen);
 	if (err < 0) {
 #ifdef CONFIG_SPL_LIBCOMMON_SUPPORT
 		printf("%s: error reading image %s, err - %d\n",

--- a/common/update_kubos.c
+++ b/common/update_kubos.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Kubos Corporation
+ * Copyright (C) 2019 Kubos Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 #include <fs.h>
 #include <mmc.h>
 #include <kubos.h>
+#include <dfu.h>
 
 #define UPDATE_COUNT_ENVAR "kubos_updatecount"
 #define DEV_ENVAR          "kubos_updatedev"
@@ -30,34 +31,132 @@
 int update_kubos_count(void)
 {
 
-	ulong count;
-	int ret = 0;
+    ulong count;
+    int ret = 0;
 
-	char *val = getenv(UPDATE_COUNT_ENVAR);
+    char *val = getenv(UPDATE_COUNT_ENVAR);
 
-	if (val == NULL)
-	{
-		setenv(UPDATE_COUNT_ENVAR, "1");
-	}
-	else
-	{
-		count = simple_strtoul(val, NULL, 10);
+    if (val == NULL)
+    {
+        setenv(UPDATE_COUNT_ENVAR, "1");
+    }
+    else
+    {
+        count = simple_strtoul(val, NULL, 10);
 
-		if (count > 1)
-		{
-			setenv(KUBOS_UPDATE_FILE, "bad");
-			setenv(UPDATE_COUNT_ENVAR, "0");
-			ret = -1;
-		}
-		else
-		{
-			count++;
-			setenv_ulong(UPDATE_COUNT_ENVAR, count);
-		}
-	}
+        if (count > 1)
+        {
+            setenv(KUBOS_UPDATE_FILE, "bad");
+            setenv(UPDATE_COUNT_ENVAR, "0");
+            ret = -1;
+        }
+        else
+        {
+            count++;
+            setenv_ulong(UPDATE_COUNT_ENVAR, count);
+        }
+    }
 
-	saveenv();
-	return ret;
+    saveenv();
+    return ret;
+}
+
+int update_mmc(char * file, void * load_addr, char * dev_num)
+{
+    loff_t actlen;
+    char * fit_image_name;
+    int ndepth, noffset;
+    // Get the file header
+    int ret = ext4_read_file(file, load_addr, 0, sizeof(struct fdt_header), &actlen);
+
+    printf("ext4_read_file RC: %d. Size: %lld\n", ret, actlen);
+
+    if (ret < 0)
+    {
+        printf("ERROR: Couldn't read %s file - %d\n", file, ret);
+        return -1;
+    }
+
+    // Get the total size of the FIT file (not including data sections)
+    int fit_size = fdt_totalsize(load_addr);
+    // Read the entire FIT file (not including data sections)
+    ret = ext4_read_file(file, load_addr, 0, fit_size, &actlen);
+
+    void * fit = load_addr;
+    // The data section will be after the FIT file, but aligned on a 32-bit
+    // boundary
+    int data_offset = (fit_size + 3) & ~3;
+    void * data_addr = load_addr + data_offset;
+
+    // Validate the file
+    if (!fit_check_format(fit)) {
+        printf("Bad FIT format of the update file, aborting "
+                            "auto-update\n");
+        return 1;
+    }
+
+    // Process updates
+    noffset = fdt_path_offset(fit, FIT_IMAGES_PATH);
+    printf("Images offset: %d\n", noffset);
+
+    ndepth = 0;
+
+    printf("Offset: %d. Depth: %d\n", noffset, ndepth);
+    while (noffset >= 0 && ndepth >= 0) {
+        noffset = fdt_next_node(fit, noffset, &ndepth);
+        printf("Next offset: %d, Next depth: %d\n", noffset, ndepth);
+
+        if (ndepth != 1) {
+            continue;
+        }
+
+        fit_image_name = (char *)fit_get_name(fit, noffset, NULL);
+        printf("Processing update '%s' :\n", fit_image_name);
+
+        // Get the update entity's size and offset
+        int update_offset, update_size;
+        if (fit_image_get_data_offset(fit, noffset, &update_offset)) {
+            printf("Error: failed to get data offset, aborting\n");
+            ret = 1;
+            continue;
+        }
+        if (fit_image_get_data_size(fit, noffset, &update_size)) {
+            printf("Error: failed to get data size, aborting\n");
+            ret = 1;
+            continue;
+        }
+
+        printf("Load addr: %p, Data offset: %d, Update offset: %d, Data size: %d\n",
+                data_addr, data_offset, update_offset, update_size);
+
+        // And load it into RAM
+        ret = ext4_read_file(file, data_addr, data_offset + update_offset,
+                update_size, &actlen);
+        printf("ext4_read_file RC: %d. Size: %lld\n", ret, actlen);
+
+        if (ret < 0)
+        {
+            printf("ERROR: Couldn't read data section - %d\n", ret);
+            return -1;
+        }
+
+//        if (!fit_image_verify(fit, noffset)) {
+//            printf("Error: invalid update hash, aborting\n");
+//            ret = 1;
+//            continue;
+//        }
+
+        if (fit_image_check_type(fit, noffset,
+                        IH_TYPE_FIRMWARE)) {
+            printf("Calling dfu_tftp_write\n");
+            ret = dfu_tftp_write(fit_image_name, (unsigned int) data_addr,
+                         update_size, "mmc", dev_num);
+            if (ret)
+                return ret;
+        }
+    }
+
+    return 0;
 }
 
 /*
@@ -81,206 +180,210 @@ int update_kubos_count(void)
 
 int update_kubos(bool upgrade)
 {
-	struct mmc *mmc;
-	disk_partition_t part_info = {};
-	char * file;
-	char * env_addr;
-	char * dfu_info;
-	loff_t actlen;
-	ulong addr, dev_num, part = 0;
+    struct mmc *mmc;
+    disk_partition_t part_info = {};
+    char * file;
+    char * env_addr;
+    char * dfu_info;
+    loff_t actlen;
+    ulong addr, dev_num, part = 0;
 
-	int ret = KUBOS_ERR_NO_REBOOT;
+    int ret = KUBOS_ERR_NO_REBOOT;
 
-	/*
-	 * Get the name of the update file to load
-	 */
-	file = getenv(KUBOS_UPDATE_FILE);
-	if (file == NULL)
-	{
-		debug("INFO: %s envar not found\n", KUBOS_UPDATE_FILE);
-		return KUBOS_ERR_NO_REBOOT;
-	}
-	else if (!strcmp(file, "none") || !strcmp(file, "bad"))
-	{
-		debug("INFO: No update file specified\n");
-		return KUBOS_ERR_NO_REBOOT;
-	}
+    /*
+     * Get the name of the update file to load
+     */
+    file = getenv(KUBOS_UPDATE_FILE);
+    if (file == NULL)
+    {
+        debug("INFO: %s envar not found\n", KUBOS_UPDATE_FILE);
+        return KUBOS_ERR_NO_REBOOT;
+    }
+    else if (!strcmp(file, "none") || !strcmp(file, "bad"))
+    {
+        debug("INFO: No update file specified\n");
+        return KUBOS_ERR_NO_REBOOT;
+    }
 
-	/*
-	 * Temp SDRAM address to load to
-	 */
-	if ((env_addr = getenv(LOAD_ENVAR)) != NULL)
-	{
-		addr = simple_strtoul(env_addr, NULL, 16);
-	}
-	else
-	{
-		addr = KUBOS_UPGRADE_STORAGE;
-	}
+    /*
+     * Temp SDRAM address to load to
+     */
+    if ((env_addr = getenv(LOAD_ENVAR)) != NULL)
+    {
+        addr = simple_strtoul(env_addr, NULL, 16);
+    }
+    else
+    {
+        addr = KUBOS_UPGRADE_STORAGE;
+    }
 
-	/*
-	 * Get and upgrade device number
-	 */
-	if ((env_addr = getenv(DEV_ENVAR)) != NULL)
-	{
-		dev_num = simple_strtoul(env_addr, NULL, 16);
-	}
-	else
-	{
-		dev_num = KUBOS_UPGRADE_DEVICE;
-	}
+    /*
+     * Get and upgrade device number
+     */
+    if ((env_addr = getenv(DEV_ENVAR)) != NULL)
+    {
+        dev_num = simple_strtoul(env_addr, NULL, 16);
+    }
+    else
+    {
+        dev_num = KUBOS_UPGRADE_DEVICE;
+    }
 
-	/*
-	 * Load the SD card
-	 */
-	mmc = find_mmc_device(dev_num);
-	if (!mmc)
-	{
-		printf("ERROR: Could not access SD card\n");
-		return KUBOS_ERR_NO_REBOOT;
+    /*
+     * Load the SD card
+     */
+    mmc = find_mmc_device(dev_num);
+    if (!mmc)
+    {
+        printf("ERROR: Could not access SD card\n");
+        return KUBOS_ERR_NO_REBOOT;
 
-	}
+    }
 
-	ret = mmc_init(mmc);
-	if (ret)
-	{
-		printf("ERROR: Could not init SD card - %d\n", ret);
-		return KUBOS_ERR_NO_REBOOT;
-	}
+    ret = mmc_init(mmc);
+    if (ret)
+    {
+        printf("ERROR: Could not init SD card - %d\n", ret);
+        return KUBOS_ERR_NO_REBOOT;
+    }
 
-	/* Increase the upgrade attempt count */
-	if (upgrade && update_kubos_count() != 0)
-	{
-		printf("ERROR: Number of update attempts exceeded. Abandoning update\n");
-		return KUBOS_ERR_NO_REBOOT;
-	}
+    /* Increase the upgrade attempt count */
+    if (upgrade && update_kubos_count() != 0)
+    {
+        printf("ERROR: Number of update attempts exceeded. Abandoning update\n");
+        return KUBOS_ERR_NO_REBOOT;
+    }
 
-	/*
-	 * Get and mount the upgrade partition
-	 */
-	if ((env_addr = getenv(PART_ENVAR)) != NULL)
-	{
-		part = simple_strtoul(env_addr, NULL, 16);
-	}
-	else
-	{
-		part = KUBOS_UPGRADE_PART;
-	}
+    /*
+     * Get and mount the upgrade partition
+     */
+    if ((env_addr = getenv(PART_ENVAR)) != NULL)
+    {
+        part = simple_strtoul(env_addr, NULL, 16);
+    }
+    else
+    {
+        part = KUBOS_UPGRADE_PART;
+    }
 
-	if (part_get_info(&mmc->block_dev, part, &part_info))
-	{
-		printf("ERROR: Could not mount upgrade partition.  No partition table\n");
-		return KUBOS_ERR_NO_REBOOT;
-	}
+    if (part_get_info(&mmc->block_dev, part, &part_info))
+    {
+        printf("ERROR: Could not mount upgrade partition.  No partition table\n");
+        return KUBOS_ERR_NO_REBOOT;
+    }
 
-	debug("INFO: Checking for new firmware files\n");
+    debug("INFO: Checking for new firmware files\n");
 
-	ext4fs_set_blk_dev(&mmc->block_dev, &part_info);
+    ext4fs_set_blk_dev(&mmc->block_dev, &part_info);
 
-	ret = ext4fs_mount(0);
-	if (!ret) {
-		printf("ERROR: Could not mount upgrade partition. ext4fs mount err - %d\n", ret);
-		return KUBOS_ERR_NO_REBOOT;
-	}
+    ret = ext4fs_mount(0);
+    if (!ret) {
+        printf("ERROR: Could not mount upgrade partition. ext4fs mount err - %d\n", ret);
+        return KUBOS_ERR_NO_REBOOT;
+    }
 
-	ret = ext4fs_exists(file);
+    ret = ext4fs_exists(file);
 
-	/*
-	 * Upgrade file found, call the existing DFU utility
-	 */
-	if (ret)
-	{
-		debug("INFO: Found file to upgrade - %s\n", file);
+    /*
+     * Upgrade file found, call the existing DFU utility
+     */
+    if (ret)
+    {
+        debug("INFO: Found file to upgrade - %s\n", file);
 
-		ret = ext4_read_file(file, (void *)addr, 0, 0, &actlen);
+        if (strstr(file,"nor") != NULL)
+        {
+            if ((dfu_info = getenv("dfu_alt_info_nor")) == NULL)
+            {
+                printf("ERROR: Can't upgrade nor files, dfu_alt_info_nor not defined\n");
+                return KUBOS_ERR_REBOOT;
+            }
 
-		if (ret < 0)
-		{
-			printf("ERROR: Couldn't read %s file - %d\n", file, ret);
-			return KUBOS_ERR_REBOOT;
-		}
-		else
-		{
-			if (strstr(file,"nor") != NULL)
-			{
-				if ((dfu_info = getenv("dfu_alt_info_nor")) == NULL)
-				{
-					printf("ERROR: Can't upgrade nor files, dfu_alt_info_nor not defined\n");
-					return KUBOS_ERR_REBOOT;
-				}
+            setenv("dfu_alt_info", dfu_info);
 
-				setenv("dfu_alt_info", dfu_info);
+            ret = ext4_read_file(file, (void *)addr, 0, 0, &actlen);
 
-				/* The "0" parameter isn't used for NOR flash, but it has to be non-NULL */
-				ret = update_tftp(addr, "nor", "0");
-			}
-			else
-			{
-				if ((dfu_info = getenv("dfu_alt_info_mmc")) == NULL)
-				{
-					printf("ERROR: Can't upgrade mmc files, dfu_alt_info_mmc not defined\n");
-					return KUBOS_ERR_REBOOT;
-				}
+            printf("ext4_read_file RC: %d. Size: %lld\n", ret, actlen);
 
-				setenv("dfu_alt_info", dfu_info);
+            if (ret < 0)
+            {
+                printf("ERROR: Couldn't read %s file - %d\n", file, ret);
+                return KUBOS_ERR_REBOOT;
+            }
+            else
+            {
+                /* The "0" parameter isn't used for NOR flash, but it has to be non-NULL */
+                ret = update_tftp(addr, "nor", "0");
+            }
+        }
+        else
+        {
+            if ((dfu_info = getenv("dfu_alt_info_mmc")) == NULL)
+            {
+                printf("ERROR: Can't upgrade mmc files, dfu_alt_info_mmc not defined\n");
+                return KUBOS_ERR_REBOOT;
+            }
 
-				/*
-				 * For right now, the "0" parameter is useless. If you add a dfu_alt_info entity
-				 * in the future which has an entity type of "raw", this might need to change
-				 * to specify a non-zero mmc device number.
-				 */
-				ret = update_tftp(addr, "mmc", "0");
-			}
+            setenv("dfu_alt_info", dfu_info);
 
-			if (ret)
-			{
-				printf("ERROR: System upgrade failed - %d\n", ret);
-				return KUBOS_ERR_REBOOT;
-			}
-			else
-			{
-				debug("INFO: Upgrade completed successfully\n");
+            /*
+             * For right now, the "0" parameter is useless. If you add a dfu_alt_info entity
+             * in the future which has an entity type of "raw", this might need to change
+             * to specify a non-zero mmc device number.
+             */
+            printf("Calling update_tftp\n");
+            ret = update_mmc(file, (void *) addr, "0");
+        }
 
-				if (upgrade)
-				{
-					/*
-					 * Only mark that we're using a new version of KubOS Linux if we're doing
-					 * a regular upgrade (vs upgrading NOR flash files)
-					 */
-					if (strstr(file,"nor") == NULL)
-					{
-						char *version = getenv(KUBOS_CURR_VERSION);
-						setenv(KUBOS_PREV_VERSION, version);
-						setenv(KUBOS_CURR_TRIED, "0");
-					}
-				}
-				else
-				{
-					if (getenv_yesno(KUBOS_CURR_TRIED) == 1)
-					{
-						setenv(KUBOS_PREV_VERSION, KUBOS_BASE);
-					}
-					else
-					{
-						setenv(KUBOS_CURR_TRIED, "1");
-					}
-				}
+        if (ret)
+        {
+            printf("ERROR: System upgrade failed - %d\n", ret);
+            return KUBOS_ERR_REBOOT;
+        }
+        else
+        {
+            debug("INFO: Upgrade completed successfully\n");
 
-				setenv(KUBOS_CURR_VERSION, file);
-				bootcount_store(0);
-			}
-		}
-	}
-	else
-	{
-		printf("ERROR: Upgrade file not found '%s'\n", file);
-		return KUBOS_ERR_REBOOT;
-	}
+            if (upgrade)
+            {
+                /*
+                 * Only mark that we're using a new version of KubOS Linux if we're doing
+                 * a regular upgrade (vs upgrading NOR flash files)
+                 */
+                if (strstr(file,"nor") == NULL)
+                {
+                    char *version = getenv(KUBOS_CURR_VERSION);
+                    setenv(KUBOS_PREV_VERSION, version);
+                    setenv(KUBOS_CURR_TRIED, "0");
+                }
+            }
+            else
+            {
+                if (getenv_yesno(KUBOS_CURR_TRIED) == 1)
+                {
+                    setenv(KUBOS_PREV_VERSION, KUBOS_BASE);
+                }
+                else
+                {
+                    setenv(KUBOS_CURR_TRIED, "1");
+                }
+            }
 
-	/* Reset the updatefile name so that we resume usual boot after rebooting */
-	setenv(KUBOS_UPDATE_FILE, "none");
-	setenv(UPDATE_COUNT_ENVAR, "0");
-	saveenv();
+            setenv(KUBOS_CURR_VERSION, file);
+            bootcount_store(0);
+        }
+    }
+    else
+    {
+        printf("ERROR: Upgrade file not found '%s'\n", file);
+        return KUBOS_ERR_REBOOT;
+    }
 
-	return KUBOS_OK_REBOOT;
+    /* Reset the updatefile name so that we resume usual boot after rebooting */
+    setenv(KUBOS_UPDATE_FILE, "none");
+    setenv(UPDATE_COUNT_ENVAR, "0");
+    saveenv();
+
+    return KUBOS_OK_REBOOT;
 }
+

--- a/fs/fat/fat_write.c
+++ b/fs/fat/fat_write.c
@@ -3,7 +3,7 @@
  *
  * R/W (V)FAT 12/16/32 filesystem implementation by Donggeun Kim
  *
- * SPDX-License-Identifier:	GPL-2.0+
+ * SPDX-License-Identifier: GPL-2.0+
  */
 
 #include <common.h>
@@ -20,33 +20,33 @@
 
 static void uppercase(char *str, int len)
 {
-	int i;
+    int i;
 
-	for (i = 0; i < len; i++) {
-		*str = toupper(*str);
-		str++;
-	}
+    for (i = 0; i < len; i++) {
+        *str = toupper(*str);
+        str++;
+    }
 }
 
 static int total_sector;
 static int disk_write(__u32 block, __u32 nr_blocks, void *buf)
 {
-	ulong ret;
+    ulong ret;
 
-	if (!cur_dev)
-		return -1;
+    if (!cur_dev)
+        return -1;
 
-	if (cur_part_info.start + block + nr_blocks >
-		cur_part_info.start + total_sector) {
-		printf("error: overflow occurs\n");
-		return -1;
-	}
+    if (cur_part_info.start + block + nr_blocks >
+        cur_part_info.start + total_sector) {
+        printf("error: overflow occurs\n");
+        return -1;
+    }
 
-	ret = blk_dwrite(cur_dev, cur_part_info.start + block, nr_blocks, buf);
-	if (nr_blocks && ret == 0)
-		return -1;
+    ret = blk_dwrite(cur_dev, cur_part_info.start + block, nr_blocks, buf);
+    if (nr_blocks && ret == 0)
+        return -1;
 
-	return ret;
+    return ret;
 }
 
 /*
@@ -54,51 +54,51 @@ static int disk_write(__u32 block, __u32 nr_blocks, void *buf)
  */
 static void set_name(dir_entry *dirent, const char *filename)
 {
-	char s_name[VFAT_MAXLEN_BYTES];
-	char *period;
-	int period_location, len, i, ext_num;
+    char s_name[VFAT_MAXLEN_BYTES];
+    char *period;
+    int period_location, len, i, ext_num;
 
-	if (filename == NULL)
-		return;
+    if (filename == NULL)
+        return;
 
-	len = strlen(filename);
-	if (len == 0)
-		return;
+    len = strlen(filename);
+    if (len == 0)
+        return;
 
-	strcpy(s_name, filename);
-	uppercase(s_name, len);
+    strcpy(s_name, filename);
+    uppercase(s_name, len);
 
-	period = strchr(s_name, '.');
-	if (period == NULL) {
-		period_location = len;
-		ext_num = 0;
-	} else {
-		period_location = period - s_name;
-		ext_num = len - period_location - 1;
-	}
+    period = strchr(s_name, '.');
+    if (period == NULL) {
+        period_location = len;
+        ext_num = 0;
+    } else {
+        period_location = period - s_name;
+        ext_num = len - period_location - 1;
+    }
 
-	/* Pad spaces when the length of file name is shorter than eight */
-	if (period_location < 8) {
-		memcpy(dirent->name, s_name, period_location);
-		for (i = period_location; i < 8; i++)
-			dirent->name[i] = ' ';
-	} else if (period_location == 8) {
-		memcpy(dirent->name, s_name, period_location);
-	} else {
-		memcpy(dirent->name, s_name, 6);
-		dirent->name[6] = '~';
-		dirent->name[7] = '1';
-	}
+    /* Pad spaces when the length of file name is shorter than eight */
+    if (period_location < 8) {
+        memcpy(dirent->name, s_name, period_location);
+        for (i = period_location; i < 8; i++)
+            dirent->name[i] = ' ';
+    } else if (period_location == 8) {
+        memcpy(dirent->name, s_name, period_location);
+    } else {
+        memcpy(dirent->name, s_name, 6);
+        dirent->name[6] = '~';
+        dirent->name[7] = '1';
+    }
 
-	if (ext_num < 3) {
-		memcpy(dirent->ext, s_name + period_location + 1, ext_num);
-		for (i = ext_num; i < 3; i++)
-			dirent->ext[i] = ' ';
-	} else
-		memcpy(dirent->ext, s_name + period_location + 1, 3);
+    if (ext_num < 3) {
+        memcpy(dirent->ext, s_name + period_location + 1, ext_num);
+        for (i = ext_num; i < 3; i++)
+            dirent->ext[i] = ' ';
+    } else
+        memcpy(dirent->ext, s_name + period_location + 1, 3);
 
-	debug("name : %s\n", dirent->name);
-	debug("ext : %s\n", dirent->ext);
+    debug("name : %s\n", dirent->name);
+    debug("ext : %s\n", dirent->ext);
 }
 
 static __u8 num_of_fats;
@@ -107,39 +107,39 @@ static __u8 num_of_fats;
  */
 static int flush_dirty_fat_buffer(fsdata *mydata)
 {
-	int getsize = FATBUFBLOCKS;
-	__u32 fatlength = mydata->fatlength;
-	__u8 *bufptr = mydata->fatbuf;
-	__u32 startblock = mydata->fatbufnum * FATBUFBLOCKS;
+    int getsize = FATBUFBLOCKS;
+    __u32 fatlength = mydata->fatlength;
+    __u8 *bufptr = mydata->fatbuf;
+    __u32 startblock = mydata->fatbufnum * FATBUFBLOCKS;
 
-	debug("debug: evicting %d, dirty: %d\n", mydata->fatbufnum,
-	      (int)mydata->fat_dirty);
+    debug("debug: evicting %d, dirty: %d\n", mydata->fatbufnum,
+          (int)mydata->fat_dirty);
 
-	if ((!mydata->fat_dirty) || (mydata->fatbufnum == -1))
-		return 0;
+    if ((!mydata->fat_dirty) || (mydata->fatbufnum == -1))
+        return 0;
 
-	startblock += mydata->fat_sect;
+    startblock += mydata->fat_sect;
 
-	if (getsize > fatlength)
-		getsize = fatlength;
+    if (getsize > fatlength)
+        getsize = fatlength;
 
-	/* Write FAT buf */
-	if (disk_write(startblock, getsize, bufptr) < 0) {
-		debug("error: writing FAT blocks\n");
-		return -1;
-	}
+    /* Write FAT buf */
+    if (disk_write(startblock, getsize, bufptr) < 0) {
+        debug("error: writing FAT blocks\n");
+        return -1;
+    }
 
-	if (num_of_fats == 2) {
-		/* Update corresponding second FAT blocks */
-		startblock += mydata->fatlength;
-		if (disk_write(startblock, getsize, bufptr) < 0) {
-			debug("error: writing second FAT blocks\n");
-			return -1;
-		}
-	}
-	mydata->fat_dirty = 0;
+    if (num_of_fats == 2) {
+        /* Update corresponding second FAT blocks */
+        startblock += mydata->fatlength;
+        if (disk_write(startblock, getsize, bufptr) < 0) {
+            debug("error: writing second FAT blocks\n");
+            return -1;
+        }
+    }
+    mydata->fat_dirty = 0;
 
-	return 0;
+    return 0;
 }
 
 /*
@@ -149,104 +149,104 @@ static int flush_dirty_fat_buffer(fsdata *mydata)
  */
 static __u32 get_fatent_value(fsdata *mydata, __u32 entry)
 {
-	__u32 bufnum;
-	__u32 off16, offset;
-	__u32 ret = 0x00;
-	__u16 val1, val2;
+    __u32 bufnum;
+    __u32 off16, offset;
+    __u32 ret = 0x00;
+    __u16 val1, val2;
 
-	if (CHECK_CLUST(entry, mydata->fatsize)) {
-		printf("Error: Invalid FAT entry: 0x%08x\n", entry);
-		return ret;
-	}
+    if (CHECK_CLUST(entry, mydata->fatsize)) {
+        printf("Error: Invalid FAT entry: 0x%08x\n", entry);
+        return ret;
+    }
 
-	switch (mydata->fatsize) {
-	case 32:
-		bufnum = entry / FAT32BUFSIZE;
-		offset = entry - bufnum * FAT32BUFSIZE;
-		break;
-	case 16:
-		bufnum = entry / FAT16BUFSIZE;
-		offset = entry - bufnum * FAT16BUFSIZE;
-		break;
-	case 12:
-		bufnum = entry / FAT12BUFSIZE;
-		offset = entry - bufnum * FAT12BUFSIZE;
-		break;
+    switch (mydata->fatsize) {
+    case 32:
+        bufnum = entry / FAT32BUFSIZE;
+        offset = entry - bufnum * FAT32BUFSIZE;
+        break;
+    case 16:
+        bufnum = entry / FAT16BUFSIZE;
+        offset = entry - bufnum * FAT16BUFSIZE;
+        break;
+    case 12:
+        bufnum = entry / FAT12BUFSIZE;
+        offset = entry - bufnum * FAT12BUFSIZE;
+        break;
 
-	default:
-		/* Unsupported FAT size */
-		return ret;
-	}
+    default:
+        /* Unsupported FAT size */
+        return ret;
+    }
 
-	debug("FAT%d: entry: 0x%04x = %d, offset: 0x%04x = %d\n",
-	       mydata->fatsize, entry, entry, offset, offset);
+    debug("FAT%d: entry: 0x%04x = %d, offset: 0x%04x = %d\n",
+           mydata->fatsize, entry, entry, offset, offset);
 
-	/* Read a new block of FAT entries into the cache. */
-	if (bufnum != mydata->fatbufnum) {
-		int getsize = FATBUFBLOCKS;
-		__u8 *bufptr = mydata->fatbuf;
-		__u32 fatlength = mydata->fatlength;
-		__u32 startblock = bufnum * FATBUFBLOCKS;
+    /* Read a new block of FAT entries into the cache. */
+    if (bufnum != mydata->fatbufnum) {
+        int getsize = FATBUFBLOCKS;
+        __u8 *bufptr = mydata->fatbuf;
+        __u32 fatlength = mydata->fatlength;
+        __u32 startblock = bufnum * FATBUFBLOCKS;
 
-		if (getsize > fatlength)
-			getsize = fatlength;
+        if (getsize > fatlength)
+            getsize = fatlength;
 
-		startblock += mydata->fat_sect;	/* Offset from start of disk */
+        startblock += mydata->fat_sect; /* Offset from start of disk */
 
-		/* Write back the fatbuf to the disk */
-		if (flush_dirty_fat_buffer(mydata) < 0)
-			return -1;
+        /* Write back the fatbuf to the disk */
+        if (flush_dirty_fat_buffer(mydata) < 0)
+            return -1;
 
-		if (disk_read(startblock, getsize, bufptr) < 0) {
-			debug("Error reading FAT blocks\n");
-			return ret;
-		}
-		mydata->fatbufnum = bufnum;
-	}
+        if (disk_read(startblock, getsize, bufptr) < 0) {
+            debug("Error reading FAT blocks\n");
+            return ret;
+        }
+        mydata->fatbufnum = bufnum;
+    }
 
-	/* Get the actual entry from the table */
-	switch (mydata->fatsize) {
-	case 32:
-		ret = FAT2CPU32(((__u32 *) mydata->fatbuf)[offset]);
-		break;
-	case 16:
-		ret = FAT2CPU16(((__u16 *) mydata->fatbuf)[offset]);
-		break;
-	case 12:
-		off16 = (offset * 3) / 4;
+    /* Get the actual entry from the table */
+    switch (mydata->fatsize) {
+    case 32:
+        ret = FAT2CPU32(((__u32 *) mydata->fatbuf)[offset]);
+        break;
+    case 16:
+        ret = FAT2CPU16(((__u16 *) mydata->fatbuf)[offset]);
+        break;
+    case 12:
+        off16 = (offset * 3) / 4;
 
-		switch (offset & 0x3) {
-		case 0:
-			ret = FAT2CPU16(((__u16 *) mydata->fatbuf)[off16]);
-			ret &= 0xfff;
-			break;
-		case 1:
-			val1 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16]);
-			val1 &= 0xf000;
-			val2 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16 + 1]);
-			val2 &= 0x00ff;
-			ret = (val2 << 4) | (val1 >> 12);
-			break;
-		case 2:
-			val1 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16]);
-			val1 &= 0xff00;
-			val2 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16 + 1]);
-			val2 &= 0x000f;
-			ret = (val2 << 8) | (val1 >> 8);
-			break;
-		case 3:
-			ret = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16]);
-			ret = (ret & 0xfff0) >> 4;
-			break;
-		default:
-			break;
-		}
-		break;
-	}
-	debug("FAT%d: ret: %08x, entry: %08x, offset: %04x\n",
-	       mydata->fatsize, ret, entry, offset);
+        switch (offset & 0x3) {
+        case 0:
+            ret = FAT2CPU16(((__u16 *) mydata->fatbuf)[off16]);
+            ret &= 0xfff;
+            break;
+        case 1:
+            val1 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16]);
+            val1 &= 0xf000;
+            val2 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16 + 1]);
+            val2 &= 0x00ff;
+            ret = (val2 << 4) | (val1 >> 12);
+            break;
+        case 2:
+            val1 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16]);
+            val1 &= 0xff00;
+            val2 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16 + 1]);
+            val2 &= 0x000f;
+            ret = (val2 << 8) | (val1 >> 8);
+            break;
+        case 3:
+            ret = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16]);
+            ret = (ret & 0xfff0) >> 4;
+            break;
+        default:
+            break;
+        }
+        break;
+    }
+    debug("FAT%d: ret: %08x, entry: %08x, offset: %04x\n",
+           mydata->fatsize, ret, entry, offset);
 
-	return ret;
+    return ret;
 }
 
 /*
@@ -254,68 +254,68 @@ static __u32 get_fatent_value(fsdata *mydata, __u32 entry)
  */
 static int str2slot(dir_slot *slotptr, const char *name, int *idx)
 {
-	int j, end_idx = 0;
+    int j, end_idx = 0;
 
-	for (j = 0; j <= 8; j += 2) {
-		if (name[*idx] == 0x00) {
-			slotptr->name0_4[j] = 0;
-			slotptr->name0_4[j + 1] = 0;
-			end_idx++;
-			goto name0_4;
-		}
-		slotptr->name0_4[j] = name[*idx];
-		(*idx)++;
-		end_idx++;
-	}
-	for (j = 0; j <= 10; j += 2) {
-		if (name[*idx] == 0x00) {
-			slotptr->name5_10[j] = 0;
-			slotptr->name5_10[j + 1] = 0;
-			end_idx++;
-			goto name5_10;
-		}
-		slotptr->name5_10[j] = name[*idx];
-		(*idx)++;
-		end_idx++;
-	}
-	for (j = 0; j <= 2; j += 2) {
-		if (name[*idx] == 0x00) {
-			slotptr->name11_12[j] = 0;
-			slotptr->name11_12[j + 1] = 0;
-			end_idx++;
-			goto name11_12;
-		}
-		slotptr->name11_12[j] = name[*idx];
-		(*idx)++;
-		end_idx++;
-	}
+    for (j = 0; j <= 8; j += 2) {
+        if (name[*idx] == 0x00) {
+            slotptr->name0_4[j] = 0;
+            slotptr->name0_4[j + 1] = 0;
+            end_idx++;
+            goto name0_4;
+        }
+        slotptr->name0_4[j] = name[*idx];
+        (*idx)++;
+        end_idx++;
+    }
+    for (j = 0; j <= 10; j += 2) {
+        if (name[*idx] == 0x00) {
+            slotptr->name5_10[j] = 0;
+            slotptr->name5_10[j + 1] = 0;
+            end_idx++;
+            goto name5_10;
+        }
+        slotptr->name5_10[j] = name[*idx];
+        (*idx)++;
+        end_idx++;
+    }
+    for (j = 0; j <= 2; j += 2) {
+        if (name[*idx] == 0x00) {
+            slotptr->name11_12[j] = 0;
+            slotptr->name11_12[j + 1] = 0;
+            end_idx++;
+            goto name11_12;
+        }
+        slotptr->name11_12[j] = name[*idx];
+        (*idx)++;
+        end_idx++;
+    }
 
-	if (name[*idx] == 0x00)
-		return 1;
+    if (name[*idx] == 0x00)
+        return 1;
 
-	return 0;
+    return 0;
 /* Not used characters are filled with 0xff 0xff */
 name0_4:
-	for (; end_idx < 5; end_idx++) {
-		slotptr->name0_4[end_idx * 2] = 0xff;
-		slotptr->name0_4[end_idx * 2 + 1] = 0xff;
-	}
-	end_idx = 5;
+    for (; end_idx < 5; end_idx++) {
+        slotptr->name0_4[end_idx * 2] = 0xff;
+        slotptr->name0_4[end_idx * 2 + 1] = 0xff;
+    }
+    end_idx = 5;
 name5_10:
-	end_idx -= 5;
-	for (; end_idx < 6; end_idx++) {
-		slotptr->name5_10[end_idx * 2] = 0xff;
-		slotptr->name5_10[end_idx * 2 + 1] = 0xff;
-	}
-	end_idx = 11;
+    end_idx -= 5;
+    for (; end_idx < 6; end_idx++) {
+        slotptr->name5_10[end_idx * 2] = 0xff;
+        slotptr->name5_10[end_idx * 2 + 1] = 0xff;
+    }
+    end_idx = 11;
 name11_12:
-	end_idx -= 11;
-	for (; end_idx < 2; end_idx++) {
-		slotptr->name11_12[end_idx * 2] = 0xff;
-		slotptr->name11_12[end_idx * 2 + 1] = 0xff;
-	}
+    end_idx -= 11;
+    for (; end_idx < 2; end_idx++) {
+        slotptr->name11_12[end_idx * 2] = 0xff;
+        slotptr->name11_12[end_idx * 2 + 1] = 0xff;
+    }
 
-	return 1;
+    return 1;
 }
 
 static int is_next_clust(fsdata *mydata, dir_entry *dentptr);
@@ -328,40 +328,40 @@ static void flush_dir_table(fsdata *mydata, dir_entry **dentptr);
 static void
 fill_dir_slot(fsdata *mydata, dir_entry **dentptr, const char *l_name)
 {
-	dir_slot *slotptr = (dir_slot *)get_contents_vfatname_block;
-	__u8 counter = 0, checksum;
-	int idx = 0, ret;
+    dir_slot *slotptr = (dir_slot *)get_contents_vfatname_block;
+    __u8 counter = 0, checksum;
+    int idx = 0, ret;
 
-	/* Get short file name checksum value */
-	checksum = mkcksum((*dentptr)->name, (*dentptr)->ext);
+    /* Get short file name checksum value */
+    checksum = mkcksum((*dentptr)->name, (*dentptr)->ext);
 
-	do {
-		memset(slotptr, 0x00, sizeof(dir_slot));
-		ret = str2slot(slotptr, l_name, &idx);
-		slotptr->id = ++counter;
-		slotptr->attr = ATTR_VFAT;
-		slotptr->alias_checksum = checksum;
-		slotptr++;
-	} while (ret == 0);
+    do {
+        memset(slotptr, 0x00, sizeof(dir_slot));
+        ret = str2slot(slotptr, l_name, &idx);
+        slotptr->id = ++counter;
+        slotptr->attr = ATTR_VFAT;
+        slotptr->alias_checksum = checksum;
+        slotptr++;
+    } while (ret == 0);
 
-	slotptr--;
-	slotptr->id |= LAST_LONG_ENTRY_MASK;
+    slotptr--;
+    slotptr->id |= LAST_LONG_ENTRY_MASK;
 
-	while (counter >= 1) {
-		if (is_next_clust(mydata, *dentptr)) {
-			/* A new cluster is allocated for directory table */
-			flush_dir_table(mydata, dentptr);
-		}
-		memcpy(*dentptr, slotptr, sizeof(dir_slot));
-		(*dentptr)++;
-		slotptr--;
-		counter--;
-	}
+    while (counter >= 1) {
+        if (is_next_clust(mydata, *dentptr)) {
+            /* A new cluster is allocated for directory table */
+            flush_dir_table(mydata, dentptr);
+        }
+        memcpy(*dentptr, slotptr, sizeof(dir_slot));
+        (*dentptr)++;
+        slotptr--;
+        counter--;
+    }
 
-	if (is_next_clust(mydata, *dentptr)) {
-		/* A new cluster is allocated for directory table */
-		flush_dir_table(mydata, dentptr);
-	}
+    if (is_next_clust(mydata, *dentptr)) {
+        /* A new cluster is allocated for directory table */
+        flush_dir_table(mydata, dentptr);
+    }
 }
 
 static __u32 dir_curclust;
@@ -377,178 +377,221 @@ static __u32 dir_curclust;
  */
 static int
 get_long_file_name(fsdata *mydata, int curclust, __u8 *cluster,
-	      dir_entry **retdent, char *l_name)
+          dir_entry **retdent, char *l_name)
 {
-	dir_entry *realdent;
-	dir_slot *slotptr = (dir_slot *)(*retdent);
-	dir_slot *slotptr2 = NULL;
-	__u8 *buflimit = cluster + mydata->sect_size * ((curclust == 0) ?
-							PREFETCH_BLOCKS :
-							mydata->clust_size);
-	__u8 counter = (slotptr->id & ~LAST_LONG_ENTRY_MASK) & 0xff;
-	int idx = 0, cur_position = 0;
+    dir_entry *realdent;
+    dir_slot *slotptr = (dir_slot *)(*retdent);
+    dir_slot *slotptr2 = NULL;
+    __u8 *buflimit = cluster + mydata->sect_size * ((curclust == 0) ?
+                            PREFETCH_BLOCKS :
+                            mydata->clust_size);
+    __u8 counter = (slotptr->id & ~LAST_LONG_ENTRY_MASK) & 0xff;
+    int idx = 0, cur_position = 0;
 
-	if (counter > VFAT_MAXSEQ) {
-		debug("Error: VFAT name is too long\n");
-		return -1;
-	}
+    if (counter > VFAT_MAXSEQ) {
+        debug("Error: VFAT name is too long\n");
+        return -1;
+    }
 
-	while ((__u8 *)slotptr < buflimit) {
-		if (counter == 0)
-			break;
-		if (((slotptr->id & ~LAST_LONG_ENTRY_MASK) & 0xff) != counter)
-			return -1;
-		slotptr++;
-		counter--;
-	}
+    while ((__u8 *)slotptr < buflimit) {
+        if (counter == 0)
+            break;
+        if (((slotptr->id & ~LAST_LONG_ENTRY_MASK) & 0xff) != counter)
+            return -1;
+        slotptr++;
+        counter--;
+    }
 
-	if ((__u8 *)slotptr >= buflimit) {
-		if (curclust == 0)
-			return -1;
-		curclust = get_fatent_value(mydata, dir_curclust);
-		if (CHECK_CLUST(curclust, mydata->fatsize)) {
-			debug("curclust: 0x%x\n", curclust);
-			printf("Invalid FAT entry\n");
-			return -1;
-		}
+    if ((__u8 *)slotptr >= buflimit) {
+        if (curclust == 0)
+            return -1;
+        curclust = get_fatent_value(mydata, dir_curclust);
+        if (CHECK_CLUST(curclust, mydata->fatsize)) {
+            debug("curclust: 0x%x\n", curclust);
+            printf("Invalid FAT entry\n");
+            return -1;
+        }
 
-		dir_curclust = curclust;
+        dir_curclust = curclust;
 
-		if (get_cluster(mydata, curclust, get_contents_vfatname_block,
-				mydata->clust_size * mydata->sect_size) != 0) {
-			debug("Error: reading directory block\n");
-			return -1;
-		}
+        if (get_cluster(mydata, curclust, get_contents_vfatname_block,
+                mydata->clust_size * mydata->sect_size) != 0) {
+            debug("Error: reading directory block\n");
+            return -1;
+        }
 
-		slotptr2 = (dir_slot *)get_contents_vfatname_block;
-		while (counter > 0) {
-			if (((slotptr2->id & ~LAST_LONG_ENTRY_MASK)
-			    & 0xff) != counter)
-				return -1;
-			slotptr2++;
-			counter--;
-		}
+        slotptr2 = (dir_slot *)get_contents_vfatname_block;
+        while (counter > 0) {
+            if (((slotptr2->id & ~LAST_LONG_ENTRY_MASK)
+                & 0xff) != counter)
+                return -1;
+            slotptr2++;
+            counter--;
+        }
 
-		/* Save the real directory entry */
-		realdent = (dir_entry *)slotptr2;
-		while ((__u8 *)slotptr2 > get_contents_vfatname_block) {
-			slotptr2--;
-			slot2str(slotptr2, l_name, &idx);
-		}
-	} else {
-		/* Save the real directory entry */
-		realdent = (dir_entry *)slotptr;
-	}
+        /* Save the real directory entry */
+        realdent = (dir_entry *)slotptr2;
+        while ((__u8 *)slotptr2 > get_contents_vfatname_block) {
+            slotptr2--;
+            slot2str(slotptr2, l_name, &idx);
+        }
+    } else {
+        /* Save the real directory entry */
+        realdent = (dir_entry *)slotptr;
+    }
 
-	do {
-		slotptr--;
-		if (slot2str(slotptr, l_name, &idx))
-			break;
-	} while (!(slotptr->id & LAST_LONG_ENTRY_MASK));
+    do {
+        slotptr--;
+        if (slot2str(slotptr, l_name, &idx))
+            break;
+    } while (!(slotptr->id & LAST_LONG_ENTRY_MASK));
 
-	l_name[idx] = '\0';
-	if (*l_name == DELETED_FLAG)
-		*l_name = '\0';
-	else if (*l_name == aRING)
-		*l_name = DELETED_FLAG;
-	downcase(l_name);
+    l_name[idx] = '\0';
+    if (*l_name == DELETED_FLAG)
+        *l_name = '\0';
+    else if (*l_name == aRING)
+        *l_name = DELETED_FLAG;
+    downcase(l_name);
 
-	/* Return the real directory entry */
-	*retdent = realdent;
+    /* Return the real directory entry */
+    *retdent = realdent;
 
-	if (slotptr2) {
-		memcpy(get_dentfromdir_block, get_contents_vfatname_block,
-			mydata->clust_size * mydata->sect_size);
-		cur_position = (__u8 *)realdent - get_contents_vfatname_block;
-		*retdent = (dir_entry *) &get_dentfromdir_block[cur_position];
-	}
+    if (slotptr2) {
+        memcpy(get_dentfromdir_block, get_contents_vfatname_block,
+            mydata->clust_size * mydata->sect_size);
+        cur_position = (__u8 *)realdent - get_contents_vfatname_block;
+        *retdent = (dir_entry *) &get_dentfromdir_block[cur_position];
+    }
 
-	return 0;
+    return 0;
 }
 
 /*
- * Set the entry at index 'entry' in a FAT (16/32) table.
+ * Set the entry at index 'entry' in a FAT (12/16/32) table.
  */
 static int set_fatent_value(fsdata *mydata, __u32 entry, __u32 entry_value)
 {
-	__u32 bufnum, offset;
+    __u32 bufnum, offset, off16;
+    __u16 val1, val2;
 
-	switch (mydata->fatsize) {
-	case 32:
-		bufnum = entry / FAT32BUFSIZE;
-		offset = entry - bufnum * FAT32BUFSIZE;
-		break;
-	case 16:
-		bufnum = entry / FAT16BUFSIZE;
-		offset = entry - bufnum * FAT16BUFSIZE;
-		break;
-	default:
-		/* Unsupported FAT size */
-		return -1;
-	}
+    switch (mydata->fatsize) {
+    case 32:
+        bufnum = entry / FAT32BUFSIZE;
+        offset = entry - bufnum * FAT32BUFSIZE;
+        break;
+    case 16:
+        bufnum = entry / FAT16BUFSIZE;
+        offset = entry - bufnum * FAT16BUFSIZE;
+        break;
+    case 12:
+        bufnum = entry / FAT12BUFSIZE;
+        offset = entry - bufnum * FAT12BUFSIZE;
+        break;
+    default:
+        /* Unsupported FAT size */
+        return -1;
+    }
 
-	/* Read a new block of FAT entries into the cache. */
-	if (bufnum != mydata->fatbufnum) {
-		int getsize = FATBUFBLOCKS;
-		__u8 *bufptr = mydata->fatbuf;
-		__u32 fatlength = mydata->fatlength;
-		__u32 startblock = bufnum * FATBUFBLOCKS;
+    /* Read a new block of FAT entries into the cache. */
+    if (bufnum != mydata->fatbufnum) {
+        int getsize = FATBUFBLOCKS;
+        __u8 *bufptr = mydata->fatbuf;
+        __u32 fatlength = mydata->fatlength;
+        __u32 startblock = bufnum * FATBUFBLOCKS;
 
-		fatlength *= mydata->sect_size;
-		startblock += mydata->fat_sect;
+        fatlength *= mydata->sect_size;
+        startblock += mydata->fat_sect;
 
-		if (getsize > fatlength)
-			getsize = fatlength;
+        if (getsize > fatlength)
+            getsize = fatlength;
 
-		if (flush_dirty_fat_buffer(mydata) < 0)
-			return -1;
+        if (flush_dirty_fat_buffer(mydata) < 0)
+            return -1;
 
-		if (disk_read(startblock, getsize, bufptr) < 0) {
-			debug("Error reading FAT blocks\n");
-			return -1;
-		}
-		mydata->fatbufnum = bufnum;
-	}
+        if (disk_read(startblock, getsize, bufptr) < 0) {
+            debug("Error reading FAT blocks\n");
+            return -1;
+        }
+        mydata->fatbufnum = bufnum;
+    }
 
-	/* Mark as dirty */
-	mydata->fat_dirty = 1;
+    /* Mark as dirty */
+    mydata->fat_dirty = 1;
 
-	/* Set the actual entry */
-	switch (mydata->fatsize) {
-	case 32:
-		((__u32 *) mydata->fatbuf)[offset] = cpu_to_le32(entry_value);
-		break;
-	case 16:
-		((__u16 *) mydata->fatbuf)[offset] = cpu_to_le16(entry_value);
-		break;
-	default:
-		return -1;
-	}
+    /* Set the actual entry */
+    switch (mydata->fatsize) {
+    case 32:
+        ((__u32 *) mydata->fatbuf)[offset] = cpu_to_le32(entry_value);
+        break;
+    case 16:
+        ((__u16 *) mydata->fatbuf)[offset] = cpu_to_le16(entry_value);
+        break;
+    case 12:
+        off16 = (offset * 3) / 4;
 
-	return 0;
+        switch (offset & 0x3) {
+        case 0:
+            val1 = cpu_to_le16(entry_value) & 0xfff;
+            ((__u16 *)mydata->fatbuf)[off16] &= ~0xfff;
+            ((__u16 *)mydata->fatbuf)[off16] |= val1;
+            break;
+        case 1:
+            val1 = cpu_to_le16(entry_value) & 0xf;
+            val2 = (cpu_to_le16(entry_value) >> 4) & 0xff;
+
+            ((__u16 *)mydata->fatbuf)[off16] &= ~0xf000;
+            ((__u16 *)mydata->fatbuf)[off16] |= (val1 << 12);
+
+            ((__u16 *)mydata->fatbuf)[off16 + 1] &= ~0xff;
+            ((__u16 *)mydata->fatbuf)[off16 + 1] |= val2;
+            break;
+        case 2:
+            val1 = cpu_to_le16(entry_value) & 0xff;
+            val2 = (cpu_to_le16(entry_value) >> 8) & 0xf;
+
+            ((__u16 *)mydata->fatbuf)[off16] &= ~0xff00;
+            ((__u16 *)mydata->fatbuf)[off16] |= (val1 << 8);
+
+            ((__u16 *)mydata->fatbuf)[off16 + 1] &= ~0xf;
+            ((__u16 *)mydata->fatbuf)[off16 + 1] |= val2;
+            break;
+        case 3:
+            val1 = cpu_to_le16(entry_value) & 0xfff;
+            ((__u16 *)mydata->fatbuf)[off16] &= ~0xfff0;
+            ((__u16 *)mydata->fatbuf)[off16] |= (val1 << 4);
+            break;
+        default:
+            break;
+        }
+        break;
+    default:
+        return -1;
+    }
+
+    return 0;
 }
 
 /*
- * Determine the next free cluster after 'entry' in a FAT (16/32) table
+* Determine the next free cluster after 'entry' in a FAT (12/16/32) table
  * and link it to 'entry'. EOC marker is not set on returned entry.
  */
 static __u32 determine_fatent(fsdata *mydata, __u32 entry)
 {
-	__u32 next_fat, next_entry = entry + 1;
+    __u32 next_fat, next_entry = entry + 1;
 
-	while (1) {
-		next_fat = get_fatent_value(mydata, next_entry);
-		if (next_fat == 0) {
-			/* found free entry, link to entry */
-			set_fatent_value(mydata, entry, next_entry);
-			break;
-		}
-		next_entry++;
-	}
-	debug("FAT%d: entry: %08x, entry_value: %04x\n",
-	       mydata->fatsize, entry, next_entry);
+    while (1) {
+        next_fat = get_fatent_value(mydata, next_entry);
+        if (next_fat == 0) {
+            /* found free entry, link to entry */
+            set_fatent_value(mydata, entry, next_entry);
+            break;
+        }
+        next_entry++;
+    }
+    debug("FAT%d: entry: %08x, entry_value: %04x\n",
+           mydata->fatsize, entry, next_entry);
 
-	return next_entry;
+    return next_entry;
 }
 
 /*
@@ -557,62 +600,62 @@ static __u32 determine_fatent(fsdata *mydata, __u32 entry)
  */
 static int
 set_cluster(fsdata *mydata, __u32 clustnum, __u8 *buffer,
-	     unsigned long size)
+         unsigned long size)
 {
-	__u32 idx = 0;
-	__u32 startsect;
-	int ret;
+    __u32 idx = 0;
+    __u32 startsect;
+    int ret;
 
-	if (clustnum > 0)
-		startsect = mydata->data_begin +
-				clustnum * mydata->clust_size;
-	else
-		startsect = mydata->rootdir_sect;
+    if (clustnum > 0)
+        startsect = mydata->data_begin +
+                clustnum * mydata->clust_size;
+    else
+        startsect = mydata->rootdir_sect;
 
-	debug("clustnum: %d, startsect: %d\n", clustnum, startsect);
+    debug("clustnum: %d, startsect: %d\n", clustnum, startsect);
 
-	if ((unsigned long)buffer & (ARCH_DMA_MINALIGN - 1)) {
-		ALLOC_CACHE_ALIGN_BUFFER(__u8, tmpbuf, mydata->sect_size);
+    if ((unsigned long)buffer & (ARCH_DMA_MINALIGN - 1)) {
+        ALLOC_CACHE_ALIGN_BUFFER(__u8, tmpbuf, mydata->sect_size);
 
-		printf("FAT: Misaligned buffer address (%p)\n", buffer);
+        printf("FAT: Misaligned buffer address (%p)\n", buffer);
 
-		while (size >= mydata->sect_size) {
-			memcpy(tmpbuf, buffer, mydata->sect_size);
-			ret = disk_write(startsect++, 1, tmpbuf);
-			if (ret != 1) {
-				debug("Error writing data (got %d)\n", ret);
-				return -1;
-			}
+        while (size >= mydata->sect_size) {
+            memcpy(tmpbuf, buffer, mydata->sect_size);
+            ret = disk_write(startsect++, 1, tmpbuf);
+            if (ret != 1) {
+                debug("Error writing data (got %d)\n", ret);
+                return -1;
+            }
 
-			buffer += mydata->sect_size;
-			size -= mydata->sect_size;
-		}
-	} else if (size >= mydata->sect_size) {
-		idx = size / mydata->sect_size;
-		ret = disk_write(startsect, idx, buffer);
-		if (ret != idx) {
-			debug("Error writing data (got %d)\n", ret);
-			return -1;
-		}
+            buffer += mydata->sect_size;
+            size -= mydata->sect_size;
+        }
+    } else if (size >= mydata->sect_size) {
+        idx = size / mydata->sect_size;
+        ret = disk_write(startsect, idx, buffer);
+        if (ret != idx) {
+            debug("Error writing data (got %d)\n", ret);
+            return -1;
+        }
 
-		startsect += idx;
-		idx *= mydata->sect_size;
-		buffer += idx;
-		size -= idx;
-	}
+        startsect += idx;
+        idx *= mydata->sect_size;
+        buffer += idx;
+        size -= idx;
+    }
 
-	if (size) {
-		ALLOC_CACHE_ALIGN_BUFFER(__u8, tmpbuf, mydata->sect_size);
+    if (size) {
+        ALLOC_CACHE_ALIGN_BUFFER(__u8, tmpbuf, mydata->sect_size);
 
-		memcpy(tmpbuf, buffer, size);
-		ret = disk_write(startsect, 1, tmpbuf);
-		if (ret != 1) {
-			debug("Error writing data (got %d)\n", ret);
-			return -1;
-		}
-	}
+        memcpy(tmpbuf, buffer, size);
+        ret = disk_write(startsect, 1, tmpbuf);
+        if (ret != 1) {
+            debug("Error writing data (got %d)\n", ret);
+            return -1;
+        }
+    }
 
-	return 0;
+    return 0;
 }
 
 /*
@@ -620,16 +663,16 @@ set_cluster(fsdata *mydata, __u32 clustnum, __u8 *buffer,
  */
 static int find_empty_cluster(fsdata *mydata)
 {
-	__u32 fat_val, entry = 3;
+    __u32 fat_val, entry = 3;
 
-	while (1) {
-		fat_val = get_fatent_value(mydata, entry);
-		if (fat_val == 0)
-			break;
-		entry++;
-	}
+    while (1) {
+        fat_val = get_fatent_value(mydata, entry);
+        if (fat_val == 0)
+            break;
+        entry++;
+    }
 
-	return entry;
+    return entry;
 }
 
 /*
@@ -637,30 +680,32 @@ static int find_empty_cluster(fsdata *mydata)
  */
 static void flush_dir_table(fsdata *mydata, dir_entry **dentptr)
 {
-	int dir_newclust = 0;
+    int dir_newclust = 0;
 
-	if (set_cluster(mydata, dir_curclust,
-		    get_dentfromdir_block,
-		    mydata->clust_size * mydata->sect_size) != 0) {
-		printf("error: wrinting directory entry\n");
-		return;
-	}
-	dir_newclust = find_empty_cluster(mydata);
-	set_fatent_value(mydata, dir_curclust, dir_newclust);
-	if (mydata->fatsize == 32)
-		set_fatent_value(mydata, dir_newclust, 0xffffff8);
-	else if (mydata->fatsize == 16)
-		set_fatent_value(mydata, dir_newclust, 0xfff8);
+    if (set_cluster(mydata, dir_curclust,
+            get_dentfromdir_block,
+            mydata->clust_size * mydata->sect_size) != 0) {
+        printf("error: wrinting directory entry\n");
+        return;
+    }
+    dir_newclust = find_empty_cluster(mydata);
+    set_fatent_value(mydata, dir_curclust, dir_newclust);
+    if (mydata->fatsize == 32)
+        set_fatent_value(mydata, dir_newclust, 0xffffff8);
+    else if (mydata->fatsize == 16)
+        set_fatent_value(mydata, dir_newclust, 0xfff8);
+    else if (mydata->fatsize == 12)
+        set_fatent_value(mydata, dir_newclust, 0xff8);
 
-	dir_curclust = dir_newclust;
+    dir_curclust = dir_newclust;
 
-	if (flush_dirty_fat_buffer(mydata) < 0)
-		return;
+    if (flush_dirty_fat_buffer(mydata) < 0)
+        return;
 
-	memset(get_dentfromdir_block, 0x00,
-		mydata->clust_size * mydata->sect_size);
+    memset(get_dentfromdir_block, 0x00,
+        mydata->clust_size * mydata->sect_size);
 
-	*dentptr = (dir_entry *) get_dentfromdir_block;
+    *dentptr = (dir_entry *) get_dentfromdir_block;
 }
 
 /*
@@ -668,26 +713,23 @@ static void flush_dir_table(fsdata *mydata, dir_entry **dentptr)
  */
 static int clear_fatent(fsdata *mydata, __u32 entry)
 {
-	__u32 fat_val;
+    __u32 fat_val;
 
-	while (1) {
-		fat_val = get_fatent_value(mydata, entry);
-		if (fat_val != 0)
-			set_fatent_value(mydata, entry, 0);
-		else
-			break;
+    while (!CHECK_CLUST(entry, mydata->fatsize)) {
+        fat_val = get_fatent_value(mydata, entry);
+        if (fat_val != 0)
+            set_fatent_value(mydata, entry, 0);
+        else
+            break;
 
-		if (fat_val == 0xfffffff || fat_val == 0xffff)
-			break;
+        entry = fat_val;
+    }
 
-		entry = fat_val;
-	}
+    /* Flush fat buffer */
+    if (flush_dirty_fat_buffer(mydata) < 0)
+        return -1;
 
-	/* Flush fat buffer */
-	if (flush_dirty_fat_buffer(mydata) < 0)
-		return -1;
-
-	return 0;
+    return 0;
 }
 
 /*
@@ -698,115 +740,117 @@ static int clear_fatent(fsdata *mydata, __u32 entry)
  */
 static int
 set_contents(fsdata *mydata, dir_entry *dentptr, __u8 *buffer,
-	      loff_t maxsize, loff_t *gotsize)
+          loff_t maxsize, loff_t *gotsize)
 {
-	loff_t filesize = FAT2CPU32(dentptr->size);
-	unsigned int bytesperclust = mydata->clust_size * mydata->sect_size;
-	__u32 curclust = START(dentptr);
-	__u32 endclust = 0, newclust = 0;
-	loff_t actsize;
+    loff_t filesize = FAT2CPU32(dentptr->size);
+    unsigned int bytesperclust = mydata->clust_size * mydata->sect_size;
+    __u32 curclust = START(dentptr);
+    __u32 endclust = 0, newclust = 0;
+    loff_t actsize;
 
-	*gotsize = 0;
-	debug("Filesize: %llu bytes\n", filesize);
+    *gotsize = 0;
+    debug("Filesize: %llu bytes\n", filesize);
 
-	if (maxsize > 0 && filesize > maxsize)
-		filesize = maxsize;
+    if (maxsize > 0 && filesize > maxsize)
+        filesize = maxsize;
 
-	debug("%llu bytes\n", filesize);
+    debug("%llu bytes\n", filesize);
 
-	if (!curclust) {
-		if (filesize) {
-			debug("error: nonempty clusterless file!\n");
-			return -1;
-		}
-		return 0;
-	}
+    if (!curclust) {
+        if (filesize) {
+            debug("error: nonempty clusterless file!\n");
+            return -1;
+        }
+        return 0;
+    }
 
-	actsize = bytesperclust;
-	endclust = curclust;
-	do {
-		/* search for consecutive clusters */
-		while (actsize < filesize) {
+    actsize = bytesperclust;
+    endclust = curclust;
+    do {
+        /* search for consecutive clusters */
+        while (actsize < filesize) {
 
 #ifdef CONFIG_AT91SAM9G20ISIS
-			WATCHDOG_RESET_COUNT(500);
+            WATCHDOG_RESET_COUNT(500);
 #else
-			WATCHDOG_RESET();
+            WATCHDOG_RESET();
 #endif
 
-			newclust = determine_fatent(mydata, endclust);
+            newclust = determine_fatent(mydata, endclust);
 
-			if ((newclust - 1) != endclust)
-				goto getit;
+            if ((newclust - 1) != endclust)
+                goto getit;
 
-			if (CHECK_CLUST(newclust, mydata->fatsize)) {
-				debug("newclust: 0x%x\n", newclust);
-				debug("Invalid FAT entry\n");
-				return 0;
-			}
-			endclust = newclust;
-			actsize += bytesperclust;
-		}
+            if (CHECK_CLUST(newclust, mydata->fatsize)) {
+                debug("newclust: 0x%x\n", newclust);
+                debug("Invalid FAT entry\n");
+                return 0;
+            }
+            endclust = newclust;
+            actsize += bytesperclust;
+        }
 
-		/* set remaining bytes */
-		actsize = filesize;
-		if (set_cluster(mydata, curclust, buffer, (int)actsize) != 0) {
-			debug("error: writing cluster\n");
-			return -1;
-		}
-		*gotsize += actsize;
+        /* set remaining bytes */
+        actsize = filesize;
+        if (set_cluster(mydata, curclust, buffer, (int)actsize) != 0) {
+            debug("error: writing cluster\n");
+            return -1;
+        }
+        *gotsize += actsize;
 
-		/* Mark end of file in FAT */
-		if (mydata->fatsize == 16)
-			newclust = 0xffff;
-		else if (mydata->fatsize == 32)
-			newclust = 0xfffffff;
-		set_fatent_value(mydata, endclust, newclust);
+        /* Mark end of file in FAT */
+        if (mydata->fatsize == 12)
+            newclust = 0xfff;
+        else if (mydata->fatsize == 16)
+            newclust = 0xffff;
+        else if (mydata->fatsize == 32)
+            newclust = 0xfffffff;
+        set_fatent_value(mydata, endclust, newclust);
 
-		return 0;
+        return 0;
 getit:
-		if (set_cluster(mydata, curclust, buffer, (int)actsize) != 0) {
-			debug("error: writing cluster\n");
-			return -1;
-		}
-		*gotsize += actsize;
-		filesize -= actsize;
-		buffer += actsize;
+        if (set_cluster(mydata, curclust, buffer, (int)actsize) != 0) {
+            debug("error: writing cluster\n");
+            return -1;
+        }
+        *gotsize += actsize;
+        filesize -= actsize;
+        buffer += actsize;
 
-		if (CHECK_CLUST(newclust, mydata->fatsize)) {
-			debug("newclust: 0x%x\n", newclust);
-			debug("Invalid FAT entry\n");
-			return 0;
-		}
-		actsize = bytesperclust;
-		curclust = endclust = newclust;
-	} while (1);
+        if (CHECK_CLUST(newclust, mydata->fatsize)) {
+            debug("newclust: 0x%x\n", newclust);
+            debug("Invalid FAT entry\n");
+            return 0;
+        }
+        actsize = bytesperclust;
+        curclust = endclust = newclust;
+    } while (1);
 }
 
 /*
  * Set start cluster in directory entry
  */
 static void set_start_cluster(const fsdata *mydata, dir_entry *dentptr,
-				__u32 start_cluster)
+                __u32 start_cluster)
 {
-	if (mydata->fatsize == 32)
-		dentptr->starthi =
-			cpu_to_le16((start_cluster & 0xffff0000) >> 16);
-	dentptr->start = cpu_to_le16(start_cluster & 0xffff);
+    if (mydata->fatsize == 32)
+        dentptr->starthi =
+            cpu_to_le16((start_cluster & 0xffff0000) >> 16);
+    dentptr->start = cpu_to_le16(start_cluster & 0xffff);
 }
 
 /*
  * Fill dir_entry
  */
 static void fill_dentry(fsdata *mydata, dir_entry *dentptr,
-	const char *filename, __u32 start_cluster, __u32 size, __u8 attr)
+    const char *filename, __u32 start_cluster, __u32 size, __u8 attr)
 {
-	set_start_cluster(mydata, dentptr, start_cluster);
-	dentptr->size = cpu_to_le32(size);
+    set_start_cluster(mydata, dentptr, start_cluster);
+    dentptr->size = cpu_to_le32(size);
 
-	dentptr->attr = attr;
+    dentptr->attr = attr;
 
-	set_name(dentptr, filename);
+    set_name(dentptr, filename);
 }
 
 /*
@@ -816,23 +860,23 @@ static void fill_dentry(fsdata *mydata, dir_entry *dentptr,
  */
 static int check_overflow(fsdata *mydata, __u32 clustnum, loff_t size)
 {
-	__u32 startsect, sect_num, offset;
+    __u32 startsect, sect_num, offset;
 
-	if (clustnum > 0) {
-		startsect = mydata->data_begin +
-				clustnum * mydata->clust_size;
-	} else {
-		startsect = mydata->rootdir_sect;
-	}
+    if (clustnum > 0) {
+        startsect = mydata->data_begin +
+                clustnum * mydata->clust_size;
+    } else {
+        startsect = mydata->rootdir_sect;
+    }
 
-	sect_num = div_u64_rem(size, mydata->sect_size, &offset);
+    sect_num = div_u64_rem(size, mydata->sect_size, &offset);
 
-	if (offset != 0)
-		sect_num++;
+    if (offset != 0)
+        sect_num++;
 
-	if (startsect + sect_num > cur_part_info.start + total_sector)
-		return -1;
-	return 0;
+    if (startsect + sect_num > cur_part_info.start + total_sector)
+        return -1;
+    return 0;
 }
 
 /*
@@ -840,14 +884,14 @@ static int check_overflow(fsdata *mydata, __u32 clustnum, loff_t size)
  */
 static int is_next_clust(fsdata *mydata, dir_entry *dentptr)
 {
-	int cur_position;
+    int cur_position;
 
-	cur_position = (__u8 *)dentptr - get_dentfromdir_block;
+    cur_position = (__u8 *)dentptr - get_dentfromdir_block;
 
-	if (cur_position >= mydata->clust_size * mydata->sect_size)
-		return 1;
-	else
-		return 0;
+    if (cur_position >= mydata->clust_size * mydata->sect_size)
+        return 1;
+    else
+        return 0;
 }
 
 static dir_entry *empty_dentptr;
@@ -857,302 +901,302 @@ static dir_entry *empty_dentptr;
  * the new position for writing a directory entry will be returned
  */
 static dir_entry *find_directory_entry(fsdata *mydata, int startsect,
-	char *filename, dir_entry *retdent, __u32 start)
+    char *filename, dir_entry *retdent, __u32 start)
 {
-	__u32 curclust = (startsect - mydata->data_begin) / mydata->clust_size;
+    __u32 curclust = (startsect - mydata->data_begin) / mydata->clust_size;
 
-	debug("get_dentfromdir: %s\n", filename);
+    debug("get_dentfromdir: %s\n", filename);
 
-	while (1) {
-		dir_entry *dentptr;
+    while (1) {
+        dir_entry *dentptr;
 
-		int i;
+        int i;
 
-		if (get_cluster(mydata, curclust, get_dentfromdir_block,
-			    mydata->clust_size * mydata->sect_size) != 0) {
-			printf("Error: reading directory block\n");
-			return NULL;
-		}
+        if (get_cluster(mydata, curclust, get_dentfromdir_block,
+                mydata->clust_size * mydata->sect_size) != 0) {
+            printf("Error: reading directory block\n");
+            return NULL;
+        }
 
-		dentptr = (dir_entry *)get_dentfromdir_block;
+        dentptr = (dir_entry *)get_dentfromdir_block;
 
-		dir_curclust = curclust;
+        dir_curclust = curclust;
 
-		for (i = 0; i < DIRENTSPERCLUST; i++) {
-			char s_name[14], l_name[VFAT_MAXLEN_BYTES];
+        for (i = 0; i < DIRENTSPERCLUST; i++) {
+            char s_name[14], l_name[VFAT_MAXLEN_BYTES];
 
-			l_name[0] = '\0';
-			if (dentptr->name[0] == DELETED_FLAG) {
-				dentptr++;
-				if (is_next_clust(mydata, dentptr))
-					break;
-				continue;
-			}
-			if ((dentptr->attr & ATTR_VOLUME)) {
-				if (vfat_enabled &&
-				    (dentptr->attr & ATTR_VFAT) &&
-				    (dentptr->name[0] & LAST_LONG_ENTRY_MASK)) {
-					get_long_file_name(mydata, curclust,
-						     get_dentfromdir_block,
-						     &dentptr, l_name);
-					debug("vfatname: |%s|\n", l_name);
-				} else {
-					/* Volume label or VFAT entry */
-					dentptr++;
-					if (is_next_clust(mydata, dentptr))
-						break;
-					continue;
-				}
-			}
-			if (dentptr->name[0] == 0) {
-				debug("Dentname == NULL - %d\n", i);
-				empty_dentptr = dentptr;
-				return NULL;
-			}
+            l_name[0] = '\0';
+            if (dentptr->name[0] == DELETED_FLAG) {
+                dentptr++;
+                if (is_next_clust(mydata, dentptr))
+                    break;
+                continue;
+            }
+            if ((dentptr->attr & ATTR_VOLUME)) {
+                if (vfat_enabled &&
+                    (dentptr->attr & ATTR_VFAT) &&
+                    (dentptr->name[0] & LAST_LONG_ENTRY_MASK)) {
+                    get_long_file_name(mydata, curclust,
+                             get_dentfromdir_block,
+                             &dentptr, l_name);
+                    debug("vfatname: |%s|\n", l_name);
+                } else {
+                    /* Volume label or VFAT entry */
+                    dentptr++;
+                    if (is_next_clust(mydata, dentptr))
+                        break;
+                    continue;
+                }
+            }
+            if (dentptr->name[0] == 0) {
+                debug("Dentname == NULL - %d\n", i);
+                empty_dentptr = dentptr;
+                return NULL;
+            }
 
-			get_name(dentptr, s_name);
+            get_name(dentptr, s_name);
 
-			if (strcmp(filename, s_name)
-			    && strcmp(filename, l_name)) {
-				debug("Mismatch: |%s|%s|\n",
-					s_name, l_name);
-				dentptr++;
-				if (is_next_clust(mydata, dentptr))
-					break;
-				continue;
-			}
+            if (strcmp(filename, s_name)
+                && strcmp(filename, l_name)) {
+                debug("Mismatch: |%s|%s|\n",
+                    s_name, l_name);
+                dentptr++;
+                if (is_next_clust(mydata, dentptr))
+                    break;
+                continue;
+            }
 
-			memcpy(retdent, dentptr, sizeof(dir_entry));
+            memcpy(retdent, dentptr, sizeof(dir_entry));
 
-			debug("DentName: %s", s_name);
-			debug(", start: 0x%x", START(dentptr));
-			debug(", size:  0x%x %s\n",
-			      FAT2CPU32(dentptr->size),
-			      (dentptr->attr & ATTR_DIR) ?
-			      "(DIR)" : "");
+            debug("DentName: %s", s_name);
+            debug(", start: 0x%x", START(dentptr));
+            debug(", size:  0x%x %s\n",
+                  FAT2CPU32(dentptr->size),
+                  (dentptr->attr & ATTR_DIR) ?
+                  "(DIR)" : "");
 
-			return dentptr;
-		}
+            return dentptr;
+        }
 
-		/*
-		 * In FAT16/12, the root dir is locate before data area, shows
-		 * in following:
-		 * -------------------------------------------------------------
-		 * | Boot | FAT1 & 2 | Root dir | Data (start from cluster #2) |
-		 * -------------------------------------------------------------
-		 *
-		 * As a result if curclust is in Root dir, it is a negative
-		 * number or 0, 1.
-		 *
-		 */
-		if (mydata->fatsize != 32 && (int)curclust <= 1) {
-			/* Current clust is in root dir, set to next clust */
-			curclust++;
-			if ((int)curclust <= 1)
-				continue;	/* continue to find */
+        /*
+         * In FAT16/12, the root dir is locate before data area, shows
+         * in following:
+         * -------------------------------------------------------------
+         * | Boot | FAT1 & 2 | Root dir | Data (start from cluster #2) |
+         * -------------------------------------------------------------
+         *
+         * As a result if curclust is in Root dir, it is a negative
+         * number or 0, 1.
+         *
+         */
+        if (mydata->fatsize != 32 && (int)curclust <= 1) {
+            /* Current clust is in root dir, set to next clust */
+            curclust++;
+            if ((int)curclust <= 1)
+                continue;   /* continue to find */
 
-			/* Reach the end of root dir */
-			empty_dentptr = dentptr;
-			return NULL;
-		}
+            /* Reach the end of root dir */
+            empty_dentptr = dentptr;
+            return NULL;
+        }
 
-		curclust = get_fatent_value(mydata, dir_curclust);
-		if (IS_LAST_CLUST(curclust, mydata->fatsize)) {
-			empty_dentptr = dentptr;
-			return NULL;
-		}
-		if (CHECK_CLUST(curclust, mydata->fatsize)) {
-			debug("curclust: 0x%x\n", curclust);
-			debug("Invalid FAT entry\n");
-			return NULL;
-		}
-	}
+        curclust = get_fatent_value(mydata, dir_curclust);
+        if (IS_LAST_CLUST(curclust, mydata->fatsize)) {
+            empty_dentptr = dentptr;
+            return NULL;
+        }
+        if (CHECK_CLUST(curclust, mydata->fatsize)) {
+            debug("curclust: 0x%x\n", curclust);
+            debug("Invalid FAT entry\n");
+            return NULL;
+        }
+    }
 
-	return NULL;
+    return NULL;
 }
 
 static int do_fat_write(const char *filename, void *buffer, loff_t size,
-			loff_t *actwrite)
+            loff_t *actwrite)
 {
-	dir_entry *dentptr, *retdent;
-	__u32 startsect;
-	__u32 start_cluster;
-	boot_sector bs;
-	volume_info volinfo;
-	fsdata datablock;
-	fsdata *mydata = &datablock;
-	int cursect;
-	int ret = -1, name_len;
-	char l_filename[VFAT_MAXLEN_BYTES];
+    dir_entry *dentptr, *retdent;
+    __u32 startsect;
+    __u32 start_cluster;
+    boot_sector bs;
+    volume_info volinfo;
+    fsdata datablock;
+    fsdata *mydata = &datablock;
+    int cursect;
+    int ret = -1, name_len;
+    char l_filename[VFAT_MAXLEN_BYTES];
 
-	*actwrite = size;
-	dir_curclust = 0;
+    *actwrite = size;
+    dir_curclust = 0;
 
-	if (read_bootsectandvi(&bs, &volinfo, &mydata->fatsize)) {
-		debug("error: reading boot sector\n");
-		return -1;
-	}
+    if (read_bootsectandvi(&bs, &volinfo, &mydata->fatsize)) {
+        debug("error: reading boot sector\n");
+        return -1;
+    }
 
-	total_sector = bs.total_sect;
-	if (total_sector == 0)
-		total_sector = (int)cur_part_info.size; /* cast of lbaint_t */
+    total_sector = bs.total_sect;
+    if (total_sector == 0)
+        total_sector = (int)cur_part_info.size; /* cast of lbaint_t */
 
-	if (mydata->fatsize == 32)
-		mydata->fatlength = bs.fat32_length;
-	else
-		mydata->fatlength = bs.fat_length;
+    if (mydata->fatsize == 32)
+        mydata->fatlength = bs.fat32_length;
+    else
+        mydata->fatlength = bs.fat_length;
 
-	mydata->fat_sect = bs.reserved;
+    mydata->fat_sect = bs.reserved;
 
-	cursect = mydata->rootdir_sect
-		= mydata->fat_sect + mydata->fatlength * bs.fats;
-	num_of_fats = bs.fats;
+    cursect = mydata->rootdir_sect
+        = mydata->fat_sect + mydata->fatlength * bs.fats;
+    num_of_fats = bs.fats;
 
-	mydata->sect_size = (bs.sector_size[1] << 8) + bs.sector_size[0];
-	mydata->clust_size = bs.cluster_size;
+    mydata->sect_size = (bs.sector_size[1] << 8) + bs.sector_size[0];
+    mydata->clust_size = bs.cluster_size;
 
-	if (mydata->fatsize == 32) {
-		mydata->data_begin = mydata->rootdir_sect -
-					(mydata->clust_size * 2);
-	} else {
-		int rootdir_size;
+    if (mydata->fatsize == 32) {
+        mydata->data_begin = mydata->rootdir_sect -
+                    (mydata->clust_size * 2);
+    } else {
+        int rootdir_size;
 
-		rootdir_size = ((bs.dir_entries[1]  * (int)256 +
-				 bs.dir_entries[0]) *
-				 sizeof(dir_entry)) /
-				 mydata->sect_size;
-		mydata->data_begin = mydata->rootdir_sect +
-					rootdir_size -
-					(mydata->clust_size * 2);
-	}
+        rootdir_size = ((bs.dir_entries[1]  * (int)256 +
+                 bs.dir_entries[0]) *
+                 sizeof(dir_entry)) /
+                 mydata->sect_size;
+        mydata->data_begin = mydata->rootdir_sect +
+                    rootdir_size -
+                    (mydata->clust_size * 2);
+    }
 
-	mydata->fatbufnum = -1;
-	mydata->fat_dirty = 0;
-	mydata->fatbuf = memalign(ARCH_DMA_MINALIGN, FATBUFSIZE);
-	if (mydata->fatbuf == NULL) {
-		debug("Error: allocating memory\n");
-		return -1;
-	}
+    mydata->fatbufnum = -1;
+    mydata->fat_dirty = 0;
+    mydata->fatbuf = memalign(ARCH_DMA_MINALIGN, FATBUFSIZE);
+    if (mydata->fatbuf == NULL) {
+        debug("Error: allocating memory\n");
+        return -1;
+    }
 
-	if (disk_read(cursect,
-		(mydata->fatsize == 32) ?
-		(mydata->clust_size) :
-		PREFETCH_BLOCKS, do_fat_read_at_block) < 0) {
-		debug("Error: reading rootdir block\n");
-		goto exit;
-	}
-	dentptr = (dir_entry *) do_fat_read_at_block;
+    if (disk_read(cursect,
+        (mydata->fatsize == 32) ?
+        (mydata->clust_size) :
+        PREFETCH_BLOCKS, do_fat_read_at_block) < 0) {
+        debug("Error: reading rootdir block\n");
+        goto exit;
+    }
+    dentptr = (dir_entry *) do_fat_read_at_block;
 
-	name_len = strlen(filename);
-	if (name_len >= VFAT_MAXLEN_BYTES)
-		name_len = VFAT_MAXLEN_BYTES - 1;
+    name_len = strlen(filename);
+    if (name_len >= VFAT_MAXLEN_BYTES)
+        name_len = VFAT_MAXLEN_BYTES - 1;
 
-	memcpy(l_filename, filename, name_len);
-	l_filename[name_len] = 0; /* terminate the string */
-	downcase(l_filename);
+    memcpy(l_filename, filename, name_len);
+    l_filename[name_len] = 0; /* terminate the string */
+    downcase(l_filename);
 
-	startsect = mydata->rootdir_sect;
-	retdent = find_directory_entry(mydata, startsect,
-				l_filename, dentptr, 0);
-	if (retdent) {
-		/* Update file size and start_cluster in a directory entry */
-		retdent->size = cpu_to_le32(size);
-		start_cluster = START(retdent);
+    startsect = mydata->rootdir_sect;
+    retdent = find_directory_entry(mydata, startsect,
+                l_filename, dentptr, 0);
+    if (retdent) {
+        /* Update file size and start_cluster in a directory entry */
+        retdent->size = cpu_to_le32(size);
+        start_cluster = START(retdent);
 
-		if (start_cluster) {
-			if (size) {
-				ret = check_overflow(mydata, start_cluster,
-							size);
-				if (ret) {
-					printf("Error: %llu overflow\n", size);
-					goto exit;
-				}
-			}
+        if (start_cluster) {
+            if (size) {
+                ret = check_overflow(mydata, start_cluster,
+                            size);
+                if (ret) {
+                    printf("Error: %llu overflow\n", size);
+                    goto exit;
+                }
+            }
 
-			ret = clear_fatent(mydata, start_cluster);
-			if (ret) {
-				printf("Error: clearing FAT entries\n");
-				goto exit;
-			}
+            ret = clear_fatent(mydata, start_cluster);
+            if (ret) {
+                printf("Error: clearing FAT entries\n");
+                goto exit;
+            }
 
-			if (!size)
-				set_start_cluster(mydata, retdent, 0);
-		} else if (size) {
-			ret = start_cluster = find_empty_cluster(mydata);
-			if (ret < 0) {
-				printf("Error: finding empty cluster\n");
-				goto exit;
-			}
+            if (!size)
+                set_start_cluster(mydata, retdent, 0);
+        } else if (size) {
+            ret = start_cluster = find_empty_cluster(mydata);
+            if (ret < 0) {
+                printf("Error: finding empty cluster\n");
+                goto exit;
+            }
 
-			ret = check_overflow(mydata, start_cluster, size);
-			if (ret) {
-				printf("Error: %llu overflow\n", size);
-				goto exit;
-			}
+            ret = check_overflow(mydata, start_cluster, size);
+            if (ret) {
+                printf("Error: %llu overflow\n", size);
+                goto exit;
+            }
 
-			set_start_cluster(mydata, retdent, start_cluster);
-		}
-	} else {
-		/* Set short name to set alias checksum field in dir_slot */
-		set_name(empty_dentptr, filename);
-		fill_dir_slot(mydata, &empty_dentptr, filename);
+            set_start_cluster(mydata, retdent, start_cluster);
+        }
+    } else {
+        /* Set short name to set alias checksum field in dir_slot */
+        set_name(empty_dentptr, filename);
+        fill_dir_slot(mydata, &empty_dentptr, filename);
 
-		if (size) {
-			ret = start_cluster = find_empty_cluster(mydata);
-			if (ret < 0) {
-				printf("Error: finding empty cluster\n");
-				goto exit;
-			}
+        if (size) {
+            ret = start_cluster = find_empty_cluster(mydata);
+            if (ret < 0) {
+                printf("Error: finding empty cluster\n");
+                goto exit;
+            }
 
-			ret = check_overflow(mydata, start_cluster, size);
-			if (ret) {
-				printf("Error: %llu overflow\n", size);
-				goto exit;
-			}
-		} else {
-			start_cluster = 0;
-		}
+            ret = check_overflow(mydata, start_cluster, size);
+            if (ret) {
+                printf("Error: %llu overflow\n", size);
+                goto exit;
+            }
+        } else {
+            start_cluster = 0;
+        }
 
-		/* Set attribute as archieve for regular file */
-		fill_dentry(mydata, empty_dentptr, filename,
-			start_cluster, size, 0x20);
+        /* Set attribute as archieve for regular file */
+        fill_dentry(mydata, empty_dentptr, filename,
+            start_cluster, size, 0x20);
 
-		retdent = empty_dentptr;
-	}
+        retdent = empty_dentptr;
+    }
 
-	ret = set_contents(mydata, retdent, buffer, size, actwrite);
-	if (ret < 0) {
-		printf("Error: writing contents\n");
-		goto exit;
-	}
-	debug("attempt to write 0x%llx bytes\n", *actwrite);
+    ret = set_contents(mydata, retdent, buffer, size, actwrite);
+    if (ret < 0) {
+        printf("Error: writing contents\n");
+        goto exit;
+    }
+    debug("attempt to write 0x%llx bytes\n", *actwrite);
 
-	/* Flush fat buffer */
-	ret = flush_dirty_fat_buffer(mydata);
-	if (ret) {
-		printf("Error: flush fat buffer\n");
-		goto exit;
-	}
+    /* Flush fat buffer */
+    ret = flush_dirty_fat_buffer(mydata);
+    if (ret) {
+        printf("Error: flush fat buffer\n");
+        goto exit;
+    }
 
-	/* Write directory table to device */
-	ret = set_cluster(mydata, dir_curclust, get_dentfromdir_block,
-			mydata->clust_size * mydata->sect_size);
-	if (ret)
-		printf("Error: writing directory entry\n");
+    /* Write directory table to device */
+    ret = set_cluster(mydata, dir_curclust, get_dentfromdir_block,
+            mydata->clust_size * mydata->sect_size);
+    if (ret)
+        printf("Error: writing directory entry\n");
 
 exit:
-	free(mydata->fatbuf);
-	return ret;
+    free(mydata->fatbuf);
+    return ret;
 }
 
 int file_fat_write(const char *filename, void *buffer, loff_t offset,
-		   loff_t maxsize, loff_t *actwrite)
+           loff_t maxsize, loff_t *actwrite)
 {
-	if (offset != 0) {
-		printf("Error: non zero offset is currently not supported.\n");
-		return -1;
-	}
+    if (offset != 0) {
+        printf("Error: non zero offset is currently not supported.\n");
+        return -1;
+    }
 
-	printf("writing %s\n", filename);
-	return do_fat_write(filename, buffer, maxsize, actwrite);
+    printf("writing %s\n", filename);
+    return do_fat_write(filename, buffer, maxsize, actwrite);
 }

--- a/fs/fat/fat_write.c
+++ b/fs/fat/fat_write.c
@@ -3,7 +3,7 @@
  *
  * R/W (V)FAT 12/16/32 filesystem implementation by Donggeun Kim
  *
- * SPDX-License-Identifier: GPL-2.0+
+ * SPDX-License-Identifier:	GPL-2.0+
  */
 
 #include <common.h>
@@ -20,33 +20,33 @@
 
 static void uppercase(char *str, int len)
 {
-    int i;
+	int i;
 
-    for (i = 0; i < len; i++) {
-        *str = toupper(*str);
-        str++;
-    }
+	for (i = 0; i < len; i++) {
+		*str = toupper(*str);
+		str++;
+	}
 }
 
 static int total_sector;
 static int disk_write(__u32 block, __u32 nr_blocks, void *buf)
 {
-    ulong ret;
+	ulong ret;
 
-    if (!cur_dev)
-        return -1;
+	if (!cur_dev)
+		return -1;
 
-    if (cur_part_info.start + block + nr_blocks >
-        cur_part_info.start + total_sector) {
-        printf("error: overflow occurs\n");
-        return -1;
-    }
+	if (cur_part_info.start + block + nr_blocks >
+		cur_part_info.start + total_sector) {
+		printf("error: overflow occurs\n");
+		return -1;
+	}
 
-    ret = blk_dwrite(cur_dev, cur_part_info.start + block, nr_blocks, buf);
-    if (nr_blocks && ret == 0)
-        return -1;
+	ret = blk_dwrite(cur_dev, cur_part_info.start + block, nr_blocks, buf);
+	if (nr_blocks && ret == 0)
+		return -1;
 
-    return ret;
+	return ret;
 }
 
 /*
@@ -54,51 +54,51 @@ static int disk_write(__u32 block, __u32 nr_blocks, void *buf)
  */
 static void set_name(dir_entry *dirent, const char *filename)
 {
-    char s_name[VFAT_MAXLEN_BYTES];
-    char *period;
-    int period_location, len, i, ext_num;
+	char s_name[VFAT_MAXLEN_BYTES];
+	char *period;
+	int period_location, len, i, ext_num;
 
-    if (filename == NULL)
-        return;
+	if (filename == NULL)
+		return;
 
-    len = strlen(filename);
-    if (len == 0)
-        return;
+	len = strlen(filename);
+	if (len == 0)
+		return;
 
-    strcpy(s_name, filename);
-    uppercase(s_name, len);
+	strcpy(s_name, filename);
+	uppercase(s_name, len);
 
-    period = strchr(s_name, '.');
-    if (period == NULL) {
-        period_location = len;
-        ext_num = 0;
-    } else {
-        period_location = period - s_name;
-        ext_num = len - period_location - 1;
-    }
+	period = strchr(s_name, '.');
+	if (period == NULL) {
+		period_location = len;
+		ext_num = 0;
+	} else {
+		period_location = period - s_name;
+		ext_num = len - period_location - 1;
+	}
 
-    /* Pad spaces when the length of file name is shorter than eight */
-    if (period_location < 8) {
-        memcpy(dirent->name, s_name, period_location);
-        for (i = period_location; i < 8; i++)
-            dirent->name[i] = ' ';
-    } else if (period_location == 8) {
-        memcpy(dirent->name, s_name, period_location);
-    } else {
-        memcpy(dirent->name, s_name, 6);
-        dirent->name[6] = '~';
-        dirent->name[7] = '1';
-    }
+	/* Pad spaces when the length of file name is shorter than eight */
+	if (period_location < 8) {
+		memcpy(dirent->name, s_name, period_location);
+		for (i = period_location; i < 8; i++)
+			dirent->name[i] = ' ';
+	} else if (period_location == 8) {
+		memcpy(dirent->name, s_name, period_location);
+	} else {
+		memcpy(dirent->name, s_name, 6);
+		dirent->name[6] = '~';
+		dirent->name[7] = '1';
+	}
 
-    if (ext_num < 3) {
-        memcpy(dirent->ext, s_name + period_location + 1, ext_num);
-        for (i = ext_num; i < 3; i++)
-            dirent->ext[i] = ' ';
-    } else
-        memcpy(dirent->ext, s_name + period_location + 1, 3);
+	if (ext_num < 3) {
+		memcpy(dirent->ext, s_name + period_location + 1, ext_num);
+		for (i = ext_num; i < 3; i++)
+			dirent->ext[i] = ' ';
+	} else
+		memcpy(dirent->ext, s_name + period_location + 1, 3);
 
-    debug("name : %s\n", dirent->name);
-    debug("ext : %s\n", dirent->ext);
+	debug("name : %s\n", dirent->name);
+	debug("ext : %s\n", dirent->ext);
 }
 
 static __u8 num_of_fats;
@@ -107,39 +107,39 @@ static __u8 num_of_fats;
  */
 static int flush_dirty_fat_buffer(fsdata *mydata)
 {
-    int getsize = FATBUFBLOCKS;
-    __u32 fatlength = mydata->fatlength;
-    __u8 *bufptr = mydata->fatbuf;
-    __u32 startblock = mydata->fatbufnum * FATBUFBLOCKS;
+	int getsize = FATBUFBLOCKS;
+	__u32 fatlength = mydata->fatlength;
+	__u8 *bufptr = mydata->fatbuf;
+	__u32 startblock = mydata->fatbufnum * FATBUFBLOCKS;
 
-    debug("debug: evicting %d, dirty: %d\n", mydata->fatbufnum,
-          (int)mydata->fat_dirty);
+	debug("debug: evicting %d, dirty: %d\n", mydata->fatbufnum,
+	      (int)mydata->fat_dirty);
 
-    if ((!mydata->fat_dirty) || (mydata->fatbufnum == -1))
-        return 0;
+	if ((!mydata->fat_dirty) || (mydata->fatbufnum == -1))
+		return 0;
 
-    startblock += mydata->fat_sect;
+	startblock += mydata->fat_sect;
 
-    if (getsize > fatlength)
-        getsize = fatlength;
+	if (getsize > fatlength)
+		getsize = fatlength;
 
-    /* Write FAT buf */
-    if (disk_write(startblock, getsize, bufptr) < 0) {
-        debug("error: writing FAT blocks\n");
-        return -1;
-    }
+	/* Write FAT buf */
+	if (disk_write(startblock, getsize, bufptr) < 0) {
+		debug("error: writing FAT blocks\n");
+		return -1;
+	}
 
-    if (num_of_fats == 2) {
-        /* Update corresponding second FAT blocks */
-        startblock += mydata->fatlength;
-        if (disk_write(startblock, getsize, bufptr) < 0) {
-            debug("error: writing second FAT blocks\n");
-            return -1;
-        }
-    }
-    mydata->fat_dirty = 0;
+	if (num_of_fats == 2) {
+		/* Update corresponding second FAT blocks */
+		startblock += mydata->fatlength;
+		if (disk_write(startblock, getsize, bufptr) < 0) {
+			debug("error: writing second FAT blocks\n");
+			return -1;
+		}
+	}
+	mydata->fat_dirty = 0;
 
-    return 0;
+	return 0;
 }
 
 /*
@@ -149,104 +149,104 @@ static int flush_dirty_fat_buffer(fsdata *mydata)
  */
 static __u32 get_fatent_value(fsdata *mydata, __u32 entry)
 {
-    __u32 bufnum;
-    __u32 off16, offset;
-    __u32 ret = 0x00;
-    __u16 val1, val2;
+	__u32 bufnum;
+	__u32 off16, offset;
+	__u32 ret = 0x00;
+	__u16 val1, val2;
 
-    if (CHECK_CLUST(entry, mydata->fatsize)) {
-        printf("Error: Invalid FAT entry: 0x%08x\n", entry);
-        return ret;
-    }
+	if (CHECK_CLUST(entry, mydata->fatsize)) {
+		printf("Error: Invalid FAT entry: 0x%08x\n", entry);
+		return ret;
+	}
 
-    switch (mydata->fatsize) {
-    case 32:
-        bufnum = entry / FAT32BUFSIZE;
-        offset = entry - bufnum * FAT32BUFSIZE;
-        break;
-    case 16:
-        bufnum = entry / FAT16BUFSIZE;
-        offset = entry - bufnum * FAT16BUFSIZE;
-        break;
-    case 12:
-        bufnum = entry / FAT12BUFSIZE;
-        offset = entry - bufnum * FAT12BUFSIZE;
-        break;
+	switch (mydata->fatsize) {
+	case 32:
+		bufnum = entry / FAT32BUFSIZE;
+		offset = entry - bufnum * FAT32BUFSIZE;
+		break;
+	case 16:
+		bufnum = entry / FAT16BUFSIZE;
+		offset = entry - bufnum * FAT16BUFSIZE;
+		break;
+	case 12:
+		bufnum = entry / FAT12BUFSIZE;
+		offset = entry - bufnum * FAT12BUFSIZE;
+		break;
 
-    default:
-        /* Unsupported FAT size */
-        return ret;
-    }
+	default:
+		/* Unsupported FAT size */
+		return ret;
+	}
 
-    debug("FAT%d: entry: 0x%04x = %d, offset: 0x%04x = %d\n",
-           mydata->fatsize, entry, entry, offset, offset);
+	debug("FAT%d: entry: 0x%04x = %d, offset: 0x%04x = %d\n",
+	       mydata->fatsize, entry, entry, offset, offset);
 
-    /* Read a new block of FAT entries into the cache. */
-    if (bufnum != mydata->fatbufnum) {
-        int getsize = FATBUFBLOCKS;
-        __u8 *bufptr = mydata->fatbuf;
-        __u32 fatlength = mydata->fatlength;
-        __u32 startblock = bufnum * FATBUFBLOCKS;
+	/* Read a new block of FAT entries into the cache. */
+	if (bufnum != mydata->fatbufnum) {
+		int getsize = FATBUFBLOCKS;
+		__u8 *bufptr = mydata->fatbuf;
+		__u32 fatlength = mydata->fatlength;
+		__u32 startblock = bufnum * FATBUFBLOCKS;
 
-        if (getsize > fatlength)
-            getsize = fatlength;
+		if (getsize > fatlength)
+			getsize = fatlength;
 
-        startblock += mydata->fat_sect; /* Offset from start of disk */
+		startblock += mydata->fat_sect;	/* Offset from start of disk */
 
-        /* Write back the fatbuf to the disk */
-        if (flush_dirty_fat_buffer(mydata) < 0)
-            return -1;
+		/* Write back the fatbuf to the disk */
+		if (flush_dirty_fat_buffer(mydata) < 0)
+			return -1;
 
-        if (disk_read(startblock, getsize, bufptr) < 0) {
-            debug("Error reading FAT blocks\n");
-            return ret;
-        }
-        mydata->fatbufnum = bufnum;
-    }
+		if (disk_read(startblock, getsize, bufptr) < 0) {
+			debug("Error reading FAT blocks\n");
+			return ret;
+		}
+		mydata->fatbufnum = bufnum;
+	}
 
-    /* Get the actual entry from the table */
-    switch (mydata->fatsize) {
-    case 32:
-        ret = FAT2CPU32(((__u32 *) mydata->fatbuf)[offset]);
-        break;
-    case 16:
-        ret = FAT2CPU16(((__u16 *) mydata->fatbuf)[offset]);
-        break;
-    case 12:
-        off16 = (offset * 3) / 4;
+	/* Get the actual entry from the table */
+	switch (mydata->fatsize) {
+	case 32:
+		ret = FAT2CPU32(((__u32 *) mydata->fatbuf)[offset]);
+		break;
+	case 16:
+		ret = FAT2CPU16(((__u16 *) mydata->fatbuf)[offset]);
+		break;
+	case 12:
+		off16 = (offset * 3) / 4;
 
-        switch (offset & 0x3) {
-        case 0:
-            ret = FAT2CPU16(((__u16 *) mydata->fatbuf)[off16]);
-            ret &= 0xfff;
-            break;
-        case 1:
-            val1 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16]);
-            val1 &= 0xf000;
-            val2 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16 + 1]);
-            val2 &= 0x00ff;
-            ret = (val2 << 4) | (val1 >> 12);
-            break;
-        case 2:
-            val1 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16]);
-            val1 &= 0xff00;
-            val2 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16 + 1]);
-            val2 &= 0x000f;
-            ret = (val2 << 8) | (val1 >> 8);
-            break;
-        case 3:
-            ret = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16]);
-            ret = (ret & 0xfff0) >> 4;
-            break;
-        default:
-            break;
-        }
-        break;
-    }
-    debug("FAT%d: ret: %08x, entry: %08x, offset: %04x\n",
-           mydata->fatsize, ret, entry, offset);
+		switch (offset & 0x3) {
+		case 0:
+			ret = FAT2CPU16(((__u16 *) mydata->fatbuf)[off16]);
+			ret &= 0xfff;
+			break;
+		case 1:
+			val1 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16]);
+			val1 &= 0xf000;
+			val2 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16 + 1]);
+			val2 &= 0x00ff;
+			ret = (val2 << 4) | (val1 >> 12);
+			break;
+		case 2:
+			val1 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16]);
+			val1 &= 0xff00;
+			val2 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16 + 1]);
+			val2 &= 0x000f;
+			ret = (val2 << 8) | (val1 >> 8);
+			break;
+		case 3:
+			ret = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16]);
+			ret = (ret & 0xfff0) >> 4;
+			break;
+		default:
+			break;
+		}
+		break;
+	}
+	debug("FAT%d: ret: %08x, entry: %08x, offset: %04x\n",
+	       mydata->fatsize, ret, entry, offset);
 
-    return ret;
+	return ret;
 }
 
 /*
@@ -254,68 +254,68 @@ static __u32 get_fatent_value(fsdata *mydata, __u32 entry)
  */
 static int str2slot(dir_slot *slotptr, const char *name, int *idx)
 {
-    int j, end_idx = 0;
+	int j, end_idx = 0;
 
-    for (j = 0; j <= 8; j += 2) {
-        if (name[*idx] == 0x00) {
-            slotptr->name0_4[j] = 0;
-            slotptr->name0_4[j + 1] = 0;
-            end_idx++;
-            goto name0_4;
-        }
-        slotptr->name0_4[j] = name[*idx];
-        (*idx)++;
-        end_idx++;
-    }
-    for (j = 0; j <= 10; j += 2) {
-        if (name[*idx] == 0x00) {
-            slotptr->name5_10[j] = 0;
-            slotptr->name5_10[j + 1] = 0;
-            end_idx++;
-            goto name5_10;
-        }
-        slotptr->name5_10[j] = name[*idx];
-        (*idx)++;
-        end_idx++;
-    }
-    for (j = 0; j <= 2; j += 2) {
-        if (name[*idx] == 0x00) {
-            slotptr->name11_12[j] = 0;
-            slotptr->name11_12[j + 1] = 0;
-            end_idx++;
-            goto name11_12;
-        }
-        slotptr->name11_12[j] = name[*idx];
-        (*idx)++;
-        end_idx++;
-    }
+	for (j = 0; j <= 8; j += 2) {
+		if (name[*idx] == 0x00) {
+			slotptr->name0_4[j] = 0;
+			slotptr->name0_4[j + 1] = 0;
+			end_idx++;
+			goto name0_4;
+		}
+		slotptr->name0_4[j] = name[*idx];
+		(*idx)++;
+		end_idx++;
+	}
+	for (j = 0; j <= 10; j += 2) {
+		if (name[*idx] == 0x00) {
+			slotptr->name5_10[j] = 0;
+			slotptr->name5_10[j + 1] = 0;
+			end_idx++;
+			goto name5_10;
+		}
+		slotptr->name5_10[j] = name[*idx];
+		(*idx)++;
+		end_idx++;
+	}
+	for (j = 0; j <= 2; j += 2) {
+		if (name[*idx] == 0x00) {
+			slotptr->name11_12[j] = 0;
+			slotptr->name11_12[j + 1] = 0;
+			end_idx++;
+			goto name11_12;
+		}
+		slotptr->name11_12[j] = name[*idx];
+		(*idx)++;
+		end_idx++;
+	}
 
-    if (name[*idx] == 0x00)
-        return 1;
+	if (name[*idx] == 0x00)
+		return 1;
 
-    return 0;
+	return 0;
 /* Not used characters are filled with 0xff 0xff */
 name0_4:
-    for (; end_idx < 5; end_idx++) {
-        slotptr->name0_4[end_idx * 2] = 0xff;
-        slotptr->name0_4[end_idx * 2 + 1] = 0xff;
-    }
-    end_idx = 5;
+	for (; end_idx < 5; end_idx++) {
+		slotptr->name0_4[end_idx * 2] = 0xff;
+		slotptr->name0_4[end_idx * 2 + 1] = 0xff;
+	}
+	end_idx = 5;
 name5_10:
-    end_idx -= 5;
-    for (; end_idx < 6; end_idx++) {
-        slotptr->name5_10[end_idx * 2] = 0xff;
-        slotptr->name5_10[end_idx * 2 + 1] = 0xff;
-    }
-    end_idx = 11;
+	end_idx -= 5;
+	for (; end_idx < 6; end_idx++) {
+		slotptr->name5_10[end_idx * 2] = 0xff;
+		slotptr->name5_10[end_idx * 2 + 1] = 0xff;
+	}
+	end_idx = 11;
 name11_12:
-    end_idx -= 11;
-    for (; end_idx < 2; end_idx++) {
-        slotptr->name11_12[end_idx * 2] = 0xff;
-        slotptr->name11_12[end_idx * 2 + 1] = 0xff;
-    }
+	end_idx -= 11;
+	for (; end_idx < 2; end_idx++) {
+		slotptr->name11_12[end_idx * 2] = 0xff;
+		slotptr->name11_12[end_idx * 2 + 1] = 0xff;
+	}
 
-    return 1;
+	return 1;
 }
 
 static int is_next_clust(fsdata *mydata, dir_entry *dentptr);
@@ -328,40 +328,40 @@ static void flush_dir_table(fsdata *mydata, dir_entry **dentptr);
 static void
 fill_dir_slot(fsdata *mydata, dir_entry **dentptr, const char *l_name)
 {
-    dir_slot *slotptr = (dir_slot *)get_contents_vfatname_block;
-    __u8 counter = 0, checksum;
-    int idx = 0, ret;
+	dir_slot *slotptr = (dir_slot *)get_contents_vfatname_block;
+	__u8 counter = 0, checksum;
+	int idx = 0, ret;
 
-    /* Get short file name checksum value */
-    checksum = mkcksum((*dentptr)->name, (*dentptr)->ext);
+	/* Get short file name checksum value */
+	checksum = mkcksum((*dentptr)->name, (*dentptr)->ext);
 
-    do {
-        memset(slotptr, 0x00, sizeof(dir_slot));
-        ret = str2slot(slotptr, l_name, &idx);
-        slotptr->id = ++counter;
-        slotptr->attr = ATTR_VFAT;
-        slotptr->alias_checksum = checksum;
-        slotptr++;
-    } while (ret == 0);
+	do {
+		memset(slotptr, 0x00, sizeof(dir_slot));
+		ret = str2slot(slotptr, l_name, &idx);
+		slotptr->id = ++counter;
+		slotptr->attr = ATTR_VFAT;
+		slotptr->alias_checksum = checksum;
+		slotptr++;
+	} while (ret == 0);
 
-    slotptr--;
-    slotptr->id |= LAST_LONG_ENTRY_MASK;
+	slotptr--;
+	slotptr->id |= LAST_LONG_ENTRY_MASK;
 
-    while (counter >= 1) {
-        if (is_next_clust(mydata, *dentptr)) {
-            /* A new cluster is allocated for directory table */
-            flush_dir_table(mydata, dentptr);
-        }
-        memcpy(*dentptr, slotptr, sizeof(dir_slot));
-        (*dentptr)++;
-        slotptr--;
-        counter--;
-    }
+	while (counter >= 1) {
+		if (is_next_clust(mydata, *dentptr)) {
+			/* A new cluster is allocated for directory table */
+			flush_dir_table(mydata, dentptr);
+		}
+		memcpy(*dentptr, slotptr, sizeof(dir_slot));
+		(*dentptr)++;
+		slotptr--;
+		counter--;
+	}
 
-    if (is_next_clust(mydata, *dentptr)) {
-        /* A new cluster is allocated for directory table */
-        flush_dir_table(mydata, dentptr);
-    }
+	if (is_next_clust(mydata, *dentptr)) {
+		/* A new cluster is allocated for directory table */
+		flush_dir_table(mydata, dentptr);
+	}
 }
 
 static __u32 dir_curclust;
@@ -377,93 +377,93 @@ static __u32 dir_curclust;
  */
 static int
 get_long_file_name(fsdata *mydata, int curclust, __u8 *cluster,
-          dir_entry **retdent, char *l_name)
+	      dir_entry **retdent, char *l_name)
 {
-    dir_entry *realdent;
-    dir_slot *slotptr = (dir_slot *)(*retdent);
-    dir_slot *slotptr2 = NULL;
-    __u8 *buflimit = cluster + mydata->sect_size * ((curclust == 0) ?
-                            PREFETCH_BLOCKS :
-                            mydata->clust_size);
-    __u8 counter = (slotptr->id & ~LAST_LONG_ENTRY_MASK) & 0xff;
-    int idx = 0, cur_position = 0;
+	dir_entry *realdent;
+	dir_slot *slotptr = (dir_slot *)(*retdent);
+	dir_slot *slotptr2 = NULL;
+	__u8 *buflimit = cluster + mydata->sect_size * ((curclust == 0) ?
+							PREFETCH_BLOCKS :
+							mydata->clust_size);
+	__u8 counter = (slotptr->id & ~LAST_LONG_ENTRY_MASK) & 0xff;
+	int idx = 0, cur_position = 0;
 
-    if (counter > VFAT_MAXSEQ) {
-        debug("Error: VFAT name is too long\n");
-        return -1;
-    }
+	if (counter > VFAT_MAXSEQ) {
+		debug("Error: VFAT name is too long\n");
+		return -1;
+	}
 
-    while ((__u8 *)slotptr < buflimit) {
-        if (counter == 0)
-            break;
-        if (((slotptr->id & ~LAST_LONG_ENTRY_MASK) & 0xff) != counter)
-            return -1;
-        slotptr++;
-        counter--;
-    }
+	while ((__u8 *)slotptr < buflimit) {
+		if (counter == 0)
+			break;
+		if (((slotptr->id & ~LAST_LONG_ENTRY_MASK) & 0xff) != counter)
+			return -1;
+		slotptr++;
+		counter--;
+	}
 
-    if ((__u8 *)slotptr >= buflimit) {
-        if (curclust == 0)
-            return -1;
-        curclust = get_fatent_value(mydata, dir_curclust);
-        if (CHECK_CLUST(curclust, mydata->fatsize)) {
-            debug("curclust: 0x%x\n", curclust);
-            printf("Invalid FAT entry\n");
-            return -1;
-        }
+	if ((__u8 *)slotptr >= buflimit) {
+		if (curclust == 0)
+			return -1;
+		curclust = get_fatent_value(mydata, dir_curclust);
+		if (CHECK_CLUST(curclust, mydata->fatsize)) {
+			debug("curclust: 0x%x\n", curclust);
+			printf("Invalid FAT entry\n");
+			return -1;
+		}
 
-        dir_curclust = curclust;
+		dir_curclust = curclust;
 
-        if (get_cluster(mydata, curclust, get_contents_vfatname_block,
-                mydata->clust_size * mydata->sect_size) != 0) {
-            debug("Error: reading directory block\n");
-            return -1;
-        }
+		if (get_cluster(mydata, curclust, get_contents_vfatname_block,
+				mydata->clust_size * mydata->sect_size) != 0) {
+			debug("Error: reading directory block\n");
+			return -1;
+		}
 
-        slotptr2 = (dir_slot *)get_contents_vfatname_block;
-        while (counter > 0) {
-            if (((slotptr2->id & ~LAST_LONG_ENTRY_MASK)
-                & 0xff) != counter)
-                return -1;
-            slotptr2++;
-            counter--;
-        }
+		slotptr2 = (dir_slot *)get_contents_vfatname_block;
+		while (counter > 0) {
+			if (((slotptr2->id & ~LAST_LONG_ENTRY_MASK)
+			    & 0xff) != counter)
+				return -1;
+			slotptr2++;
+			counter--;
+		}
 
-        /* Save the real directory entry */
-        realdent = (dir_entry *)slotptr2;
-        while ((__u8 *)slotptr2 > get_contents_vfatname_block) {
-            slotptr2--;
-            slot2str(slotptr2, l_name, &idx);
-        }
-    } else {
-        /* Save the real directory entry */
-        realdent = (dir_entry *)slotptr;
-    }
+		/* Save the real directory entry */
+		realdent = (dir_entry *)slotptr2;
+		while ((__u8 *)slotptr2 > get_contents_vfatname_block) {
+			slotptr2--;
+			slot2str(slotptr2, l_name, &idx);
+		}
+	} else {
+		/* Save the real directory entry */
+		realdent = (dir_entry *)slotptr;
+	}
 
-    do {
-        slotptr--;
-        if (slot2str(slotptr, l_name, &idx))
-            break;
-    } while (!(slotptr->id & LAST_LONG_ENTRY_MASK));
+	do {
+		slotptr--;
+		if (slot2str(slotptr, l_name, &idx))
+			break;
+	} while (!(slotptr->id & LAST_LONG_ENTRY_MASK));
 
-    l_name[idx] = '\0';
-    if (*l_name == DELETED_FLAG)
-        *l_name = '\0';
-    else if (*l_name == aRING)
-        *l_name = DELETED_FLAG;
-    downcase(l_name);
+	l_name[idx] = '\0';
+	if (*l_name == DELETED_FLAG)
+		*l_name = '\0';
+	else if (*l_name == aRING)
+		*l_name = DELETED_FLAG;
+	downcase(l_name);
 
-    /* Return the real directory entry */
-    *retdent = realdent;
+	/* Return the real directory entry */
+	*retdent = realdent;
 
-    if (slotptr2) {
-        memcpy(get_dentfromdir_block, get_contents_vfatname_block,
-            mydata->clust_size * mydata->sect_size);
-        cur_position = (__u8 *)realdent - get_contents_vfatname_block;
-        *retdent = (dir_entry *) &get_dentfromdir_block[cur_position];
-    }
+	if (slotptr2) {
+		memcpy(get_dentfromdir_block, get_contents_vfatname_block,
+			mydata->clust_size * mydata->sect_size);
+		cur_position = (__u8 *)realdent - get_contents_vfatname_block;
+		*retdent = (dir_entry *) &get_dentfromdir_block[cur_position];
+	}
 
-    return 0;
+	return 0;
 }
 
 /*
@@ -471,127 +471,127 @@ get_long_file_name(fsdata *mydata, int curclust, __u8 *cluster,
  */
 static int set_fatent_value(fsdata *mydata, __u32 entry, __u32 entry_value)
 {
-    __u32 bufnum, offset, off16;
-    __u16 val1, val2;
+	__u32 bufnum, offset, off16;
+	__u16 val1, val2;
 
-    switch (mydata->fatsize) {
-    case 32:
-        bufnum = entry / FAT32BUFSIZE;
-        offset = entry - bufnum * FAT32BUFSIZE;
-        break;
-    case 16:
-        bufnum = entry / FAT16BUFSIZE;
-        offset = entry - bufnum * FAT16BUFSIZE;
-        break;
-    case 12:
-        bufnum = entry / FAT12BUFSIZE;
-        offset = entry - bufnum * FAT12BUFSIZE;
-        break;
-    default:
-        /* Unsupported FAT size */
-        return -1;
-    }
+	switch (mydata->fatsize) {
+	case 32:
+		bufnum = entry / FAT32BUFSIZE;
+		offset = entry - bufnum * FAT32BUFSIZE;
+		break;
+	case 16:
+		bufnum = entry / FAT16BUFSIZE;
+		offset = entry - bufnum * FAT16BUFSIZE;
+		break;
+	case 12:
+		bufnum = entry / FAT12BUFSIZE;
+		offset = entry - bufnum * FAT12BUFSIZE;
+		break;
+	default:
+		/* Unsupported FAT size */
+		return -1;
+	}
 
-    /* Read a new block of FAT entries into the cache. */
-    if (bufnum != mydata->fatbufnum) {
-        int getsize = FATBUFBLOCKS;
-        __u8 *bufptr = mydata->fatbuf;
-        __u32 fatlength = mydata->fatlength;
-        __u32 startblock = bufnum * FATBUFBLOCKS;
+	/* Read a new block of FAT entries into the cache. */
+	if (bufnum != mydata->fatbufnum) {
+		int getsize = FATBUFBLOCKS;
+		__u8 *bufptr = mydata->fatbuf;
+		__u32 fatlength = mydata->fatlength;
+		__u32 startblock = bufnum * FATBUFBLOCKS;
 
-        fatlength *= mydata->sect_size;
-        startblock += mydata->fat_sect;
+		fatlength *= mydata->sect_size;
+		startblock += mydata->fat_sect;
 
-        if (getsize > fatlength)
-            getsize = fatlength;
+		if (getsize > fatlength)
+			getsize = fatlength;
 
-        if (flush_dirty_fat_buffer(mydata) < 0)
-            return -1;
+		if (flush_dirty_fat_buffer(mydata) < 0)
+			return -1;
 
-        if (disk_read(startblock, getsize, bufptr) < 0) {
-            debug("Error reading FAT blocks\n");
-            return -1;
-        }
-        mydata->fatbufnum = bufnum;
-    }
+		if (disk_read(startblock, getsize, bufptr) < 0) {
+			debug("Error reading FAT blocks\n");
+			return -1;
+		}
+		mydata->fatbufnum = bufnum;
+	}
 
-    /* Mark as dirty */
-    mydata->fat_dirty = 1;
+	/* Mark as dirty */
+	mydata->fat_dirty = 1;
 
-    /* Set the actual entry */
-    switch (mydata->fatsize) {
-    case 32:
-        ((__u32 *) mydata->fatbuf)[offset] = cpu_to_le32(entry_value);
-        break;
-    case 16:
-        ((__u16 *) mydata->fatbuf)[offset] = cpu_to_le16(entry_value);
-        break;
-    case 12:
-        off16 = (offset * 3) / 4;
+	/* Set the actual entry */
+	switch (mydata->fatsize) {
+	case 32:
+		((__u32 *) mydata->fatbuf)[offset] = cpu_to_le32(entry_value);
+		break;
+	case 16:
+		((__u16 *) mydata->fatbuf)[offset] = cpu_to_le16(entry_value);
+		break;
+	case 12:
+		off16 = (offset * 3) / 4;
 
-        switch (offset & 0x3) {
-        case 0:
-            val1 = cpu_to_le16(entry_value) & 0xfff;
-            ((__u16 *)mydata->fatbuf)[off16] &= ~0xfff;
-            ((__u16 *)mydata->fatbuf)[off16] |= val1;
-            break;
-        case 1:
-            val1 = cpu_to_le16(entry_value) & 0xf;
-            val2 = (cpu_to_le16(entry_value) >> 4) & 0xff;
+		switch (offset & 0x3) {
+		case 0:
+			val1 = cpu_to_le16(entry_value) & 0xfff;
+			((__u16 *)mydata->fatbuf)[off16] &= ~0xfff;
+			((__u16 *)mydata->fatbuf)[off16] |= val1;
+			break;
+		case 1:
+			val1 = cpu_to_le16(entry_value) & 0xf;
+			val2 = (cpu_to_le16(entry_value) >> 4) & 0xff;
 
-            ((__u16 *)mydata->fatbuf)[off16] &= ~0xf000;
-            ((__u16 *)mydata->fatbuf)[off16] |= (val1 << 12);
+			((__u16 *)mydata->fatbuf)[off16] &= ~0xf000;
+			((__u16 *)mydata->fatbuf)[off16] |= (val1 << 12);
 
-            ((__u16 *)mydata->fatbuf)[off16 + 1] &= ~0xff;
-            ((__u16 *)mydata->fatbuf)[off16 + 1] |= val2;
-            break;
-        case 2:
-            val1 = cpu_to_le16(entry_value) & 0xff;
-            val2 = (cpu_to_le16(entry_value) >> 8) & 0xf;
+			((__u16 *)mydata->fatbuf)[off16 + 1] &= ~0xff;
+			((__u16 *)mydata->fatbuf)[off16 + 1] |= val2;
+			break;
+		case 2:
+			val1 = cpu_to_le16(entry_value) & 0xff;
+			val2 = (cpu_to_le16(entry_value) >> 8) & 0xf;
 
-            ((__u16 *)mydata->fatbuf)[off16] &= ~0xff00;
-            ((__u16 *)mydata->fatbuf)[off16] |= (val1 << 8);
+			((__u16 *)mydata->fatbuf)[off16] &= ~0xff00;
+			((__u16 *)mydata->fatbuf)[off16] |= (val1 << 8);
 
-            ((__u16 *)mydata->fatbuf)[off16 + 1] &= ~0xf;
-            ((__u16 *)mydata->fatbuf)[off16 + 1] |= val2;
-            break;
-        case 3:
-            val1 = cpu_to_le16(entry_value) & 0xfff;
-            ((__u16 *)mydata->fatbuf)[off16] &= ~0xfff0;
-            ((__u16 *)mydata->fatbuf)[off16] |= (val1 << 4);
-            break;
-        default:
-            break;
-        }
-        break;
-    default:
-        return -1;
-    }
+			((__u16 *)mydata->fatbuf)[off16 + 1] &= ~0xf;
+			((__u16 *)mydata->fatbuf)[off16 + 1] |= val2;
+			break;
+		case 3:
+			val1 = cpu_to_le16(entry_value) & 0xfff;
+			((__u16 *)mydata->fatbuf)[off16] &= ~0xfff0;
+			((__u16 *)mydata->fatbuf)[off16] |= (val1 << 4);
+			break;
+		default:
+			break;
+		}
+		break;
+	default:
+		return -1;
+	}
 
-    return 0;
+	return 0;
 }
 
 /*
-* Determine the next free cluster after 'entry' in a FAT (12/16/32) table
+ * Determine the next free cluster after 'entry' in a FAT (12/16/32) table
  * and link it to 'entry'. EOC marker is not set on returned entry.
  */
 static __u32 determine_fatent(fsdata *mydata, __u32 entry)
 {
-    __u32 next_fat, next_entry = entry + 1;
+	__u32 next_fat, next_entry = entry + 1;
 
-    while (1) {
-        next_fat = get_fatent_value(mydata, next_entry);
-        if (next_fat == 0) {
-            /* found free entry, link to entry */
-            set_fatent_value(mydata, entry, next_entry);
-            break;
-        }
-        next_entry++;
-    }
-    debug("FAT%d: entry: %08x, entry_value: %04x\n",
-           mydata->fatsize, entry, next_entry);
+	while (1) {
+		next_fat = get_fatent_value(mydata, next_entry);
+		if (next_fat == 0) {
+			/* found free entry, link to entry */
+			set_fatent_value(mydata, entry, next_entry);
+			break;
+		}
+		next_entry++;
+	}
+	debug("FAT%d: entry: %08x, entry_value: %04x\n",
+	       mydata->fatsize, entry, next_entry);
 
-    return next_entry;
+	return next_entry;
 }
 
 /*
@@ -600,62 +600,62 @@ static __u32 determine_fatent(fsdata *mydata, __u32 entry)
  */
 static int
 set_cluster(fsdata *mydata, __u32 clustnum, __u8 *buffer,
-         unsigned long size)
+	     unsigned long size)
 {
-    __u32 idx = 0;
-    __u32 startsect;
-    int ret;
+	__u32 idx = 0;
+	__u32 startsect;
+	int ret;
 
-    if (clustnum > 0)
-        startsect = mydata->data_begin +
-                clustnum * mydata->clust_size;
-    else
-        startsect = mydata->rootdir_sect;
+	if (clustnum > 0)
+		startsect = mydata->data_begin +
+				clustnum * mydata->clust_size;
+	else
+		startsect = mydata->rootdir_sect;
 
-    debug("clustnum: %d, startsect: %d\n", clustnum, startsect);
+	debug("clustnum: %d, startsect: %d\n", clustnum, startsect);
 
-    if ((unsigned long)buffer & (ARCH_DMA_MINALIGN - 1)) {
-        ALLOC_CACHE_ALIGN_BUFFER(__u8, tmpbuf, mydata->sect_size);
+	if ((unsigned long)buffer & (ARCH_DMA_MINALIGN - 1)) {
+		ALLOC_CACHE_ALIGN_BUFFER(__u8, tmpbuf, mydata->sect_size);
 
-        printf("FAT: Misaligned buffer address (%p)\n", buffer);
+		printf("FAT: Misaligned buffer address (%p)\n", buffer);
 
-        while (size >= mydata->sect_size) {
-            memcpy(tmpbuf, buffer, mydata->sect_size);
-            ret = disk_write(startsect++, 1, tmpbuf);
-            if (ret != 1) {
-                debug("Error writing data (got %d)\n", ret);
-                return -1;
-            }
+		while (size >= mydata->sect_size) {
+			memcpy(tmpbuf, buffer, mydata->sect_size);
+			ret = disk_write(startsect++, 1, tmpbuf);
+			if (ret != 1) {
+				debug("Error writing data (got %d)\n", ret);
+				return -1;
+			}
 
-            buffer += mydata->sect_size;
-            size -= mydata->sect_size;
-        }
-    } else if (size >= mydata->sect_size) {
-        idx = size / mydata->sect_size;
-        ret = disk_write(startsect, idx, buffer);
-        if (ret != idx) {
-            debug("Error writing data (got %d)\n", ret);
-            return -1;
-        }
+			buffer += mydata->sect_size;
+			size -= mydata->sect_size;
+		}
+	} else if (size >= mydata->sect_size) {
+		idx = size / mydata->sect_size;
+		ret = disk_write(startsect, idx, buffer);
+		if (ret != idx) {
+			debug("Error writing data (got %d)\n", ret);
+			return -1;
+		}
 
-        startsect += idx;
-        idx *= mydata->sect_size;
-        buffer += idx;
-        size -= idx;
-    }
+		startsect += idx;
+		idx *= mydata->sect_size;
+		buffer += idx;
+		size -= idx;
+	}
 
-    if (size) {
-        ALLOC_CACHE_ALIGN_BUFFER(__u8, tmpbuf, mydata->sect_size);
+	if (size) {
+		ALLOC_CACHE_ALIGN_BUFFER(__u8, tmpbuf, mydata->sect_size);
 
-        memcpy(tmpbuf, buffer, size);
-        ret = disk_write(startsect, 1, tmpbuf);
-        if (ret != 1) {
-            debug("Error writing data (got %d)\n", ret);
-            return -1;
-        }
-    }
+		memcpy(tmpbuf, buffer, size);
+		ret = disk_write(startsect, 1, tmpbuf);
+		if (ret != 1) {
+			debug("Error writing data (got %d)\n", ret);
+			return -1;
+		}
+	}
 
-    return 0;
+	return 0;
 }
 
 /*
@@ -663,16 +663,16 @@ set_cluster(fsdata *mydata, __u32 clustnum, __u8 *buffer,
  */
 static int find_empty_cluster(fsdata *mydata)
 {
-    __u32 fat_val, entry = 3;
+	__u32 fat_val, entry = 3;
 
-    while (1) {
-        fat_val = get_fatent_value(mydata, entry);
-        if (fat_val == 0)
-            break;
-        entry++;
-    }
+	while (1) {
+		fat_val = get_fatent_value(mydata, entry);
+		if (fat_val == 0)
+			break;
+		entry++;
+	}
 
-    return entry;
+	return entry;
 }
 
 /*
@@ -680,32 +680,32 @@ static int find_empty_cluster(fsdata *mydata)
  */
 static void flush_dir_table(fsdata *mydata, dir_entry **dentptr)
 {
-    int dir_newclust = 0;
+	int dir_newclust = 0;
 
-    if (set_cluster(mydata, dir_curclust,
-            get_dentfromdir_block,
-            mydata->clust_size * mydata->sect_size) != 0) {
-        printf("error: wrinting directory entry\n");
-        return;
-    }
-    dir_newclust = find_empty_cluster(mydata);
-    set_fatent_value(mydata, dir_curclust, dir_newclust);
-    if (mydata->fatsize == 32)
-        set_fatent_value(mydata, dir_newclust, 0xffffff8);
-    else if (mydata->fatsize == 16)
-        set_fatent_value(mydata, dir_newclust, 0xfff8);
-    else if (mydata->fatsize == 12)
-        set_fatent_value(mydata, dir_newclust, 0xff8);
+	if (set_cluster(mydata, dir_curclust,
+		    get_dentfromdir_block,
+		    mydata->clust_size * mydata->sect_size) != 0) {
+		printf("error: wrinting directory entry\n");
+		return;
+	}
+	dir_newclust = find_empty_cluster(mydata);
+	set_fatent_value(mydata, dir_curclust, dir_newclust);
+	if (mydata->fatsize == 32)
+		set_fatent_value(mydata, dir_newclust, 0xffffff8);
+	else if (mydata->fatsize == 16)
+		set_fatent_value(mydata, dir_newclust, 0xfff8);
+	else if (mydata->fatsize == 12)
+		set_fatent_value(mydata, dir_newclust, 0xff8);
 
-    dir_curclust = dir_newclust;
+	dir_curclust = dir_newclust;
 
-    if (flush_dirty_fat_buffer(mydata) < 0)
-        return;
+	if (flush_dirty_fat_buffer(mydata) < 0)
+		return;
 
-    memset(get_dentfromdir_block, 0x00,
-        mydata->clust_size * mydata->sect_size);
+	memset(get_dentfromdir_block, 0x00,
+		mydata->clust_size * mydata->sect_size);
 
-    *dentptr = (dir_entry *) get_dentfromdir_block;
+	*dentptr = (dir_entry *) get_dentfromdir_block;
 }
 
 /*
@@ -713,23 +713,23 @@ static void flush_dir_table(fsdata *mydata, dir_entry **dentptr)
  */
 static int clear_fatent(fsdata *mydata, __u32 entry)
 {
-    __u32 fat_val;
+	__u32 fat_val;
 
-    while (!CHECK_CLUST(entry, mydata->fatsize)) {
-        fat_val = get_fatent_value(mydata, entry);
-        if (fat_val != 0)
-            set_fatent_value(mydata, entry, 0);
-        else
-            break;
+	while (!CHECK_CLUST(entry, mydata->fatsize)) {
+		fat_val = get_fatent_value(mydata, entry);
+		if (fat_val != 0)
+			set_fatent_value(mydata, entry, 0);
+		else
+			break;
 
-        entry = fat_val;
-    }
+		entry = fat_val;
+	}
 
-    /* Flush fat buffer */
-    if (flush_dirty_fat_buffer(mydata) < 0)
-        return -1;
+	/* Flush fat buffer */
+	if (flush_dirty_fat_buffer(mydata) < 0)
+		return -1;
 
-    return 0;
+	return 0;
 }
 
 /*
@@ -740,117 +740,117 @@ static int clear_fatent(fsdata *mydata, __u32 entry)
  */
 static int
 set_contents(fsdata *mydata, dir_entry *dentptr, __u8 *buffer,
-          loff_t maxsize, loff_t *gotsize)
+	      loff_t maxsize, loff_t *gotsize)
 {
-    loff_t filesize = FAT2CPU32(dentptr->size);
-    unsigned int bytesperclust = mydata->clust_size * mydata->sect_size;
-    __u32 curclust = START(dentptr);
-    __u32 endclust = 0, newclust = 0;
-    loff_t actsize;
+	loff_t filesize = FAT2CPU32(dentptr->size);
+	unsigned int bytesperclust = mydata->clust_size * mydata->sect_size;
+	__u32 curclust = START(dentptr);
+	__u32 endclust = 0, newclust = 0;
+	loff_t actsize;
 
-    *gotsize = 0;
-    debug("Filesize: %llu bytes\n", filesize);
+	*gotsize = 0;
+	debug("Filesize: %llu bytes\n", filesize);
 
-    if (maxsize > 0 && filesize > maxsize)
-        filesize = maxsize;
+	if (maxsize > 0 && filesize > maxsize)
+		filesize = maxsize;
 
-    debug("%llu bytes\n", filesize);
+	debug("%llu bytes\n", filesize);
 
-    if (!curclust) {
-        if (filesize) {
-            debug("error: nonempty clusterless file!\n");
-            return -1;
-        }
-        return 0;
-    }
+	if (!curclust) {
+		if (filesize) {
+			debug("error: nonempty clusterless file!\n");
+			return -1;
+		}
+		return 0;
+	}
 
-    actsize = bytesperclust;
-    endclust = curclust;
-    do {
-        /* search for consecutive clusters */
-        while (actsize < filesize) {
+	actsize = bytesperclust;
+	endclust = curclust;
+	do {
+		/* search for consecutive clusters */
+		while (actsize < filesize) {
 
 #ifdef CONFIG_AT91SAM9G20ISIS
-            WATCHDOG_RESET_COUNT(500);
+			WATCHDOG_RESET_COUNT(500);
 #else
-            WATCHDOG_RESET();
+			WATCHDOG_RESET();
 #endif
 
-            newclust = determine_fatent(mydata, endclust);
+			newclust = determine_fatent(mydata, endclust);
 
-            if ((newclust - 1) != endclust)
-                goto getit;
+			if ((newclust - 1) != endclust)
+				goto getit;
 
-            if (CHECK_CLUST(newclust, mydata->fatsize)) {
-                debug("newclust: 0x%x\n", newclust);
-                debug("Invalid FAT entry\n");
-                return 0;
-            }
-            endclust = newclust;
-            actsize += bytesperclust;
-        }
+			if (CHECK_CLUST(newclust, mydata->fatsize)) {
+				debug("newclust: 0x%x\n", newclust);
+				debug("Invalid FAT entry\n");
+				return 0;
+			}
+			endclust = newclust;
+			actsize += bytesperclust;
+		}
 
-        /* set remaining bytes */
-        actsize = filesize;
-        if (set_cluster(mydata, curclust, buffer, (int)actsize) != 0) {
-            debug("error: writing cluster\n");
-            return -1;
-        }
-        *gotsize += actsize;
+		/* set remaining bytes */
+		actsize = filesize;
+		if (set_cluster(mydata, curclust, buffer, (int)actsize) != 0) {
+			debug("error: writing cluster\n");
+			return -1;
+		}
+		*gotsize += actsize;
 
-        /* Mark end of file in FAT */
-        if (mydata->fatsize == 12)
-            newclust = 0xfff;
-        else if (mydata->fatsize == 16)
-            newclust = 0xffff;
-        else if (mydata->fatsize == 32)
-            newclust = 0xfffffff;
-        set_fatent_value(mydata, endclust, newclust);
+		/* Mark end of file in FAT */
+		if (mydata->fatsize == 12)
+			newclust = 0xfff;
+		else if (mydata->fatsize == 16)
+			newclust = 0xffff;
+		else if (mydata->fatsize == 32)
+			newclust = 0xfffffff;
+		set_fatent_value(mydata, endclust, newclust);
 
-        return 0;
+		return 0;
 getit:
-        if (set_cluster(mydata, curclust, buffer, (int)actsize) != 0) {
-            debug("error: writing cluster\n");
-            return -1;
-        }
-        *gotsize += actsize;
-        filesize -= actsize;
-        buffer += actsize;
+		if (set_cluster(mydata, curclust, buffer, (int)actsize) != 0) {
+			debug("error: writing cluster\n");
+			return -1;
+		}
+		*gotsize += actsize;
+		filesize -= actsize;
+		buffer += actsize;
 
-        if (CHECK_CLUST(newclust, mydata->fatsize)) {
-            debug("newclust: 0x%x\n", newclust);
-            debug("Invalid FAT entry\n");
-            return 0;
-        }
-        actsize = bytesperclust;
-        curclust = endclust = newclust;
-    } while (1);
+		if (CHECK_CLUST(newclust, mydata->fatsize)) {
+			debug("newclust: 0x%x\n", newclust);
+			debug("Invalid FAT entry\n");
+			return 0;
+		}
+		actsize = bytesperclust;
+		curclust = endclust = newclust;
+	} while (1);
 }
 
 /*
  * Set start cluster in directory entry
  */
 static void set_start_cluster(const fsdata *mydata, dir_entry *dentptr,
-                __u32 start_cluster)
+				__u32 start_cluster)
 {
-    if (mydata->fatsize == 32)
-        dentptr->starthi =
-            cpu_to_le16((start_cluster & 0xffff0000) >> 16);
-    dentptr->start = cpu_to_le16(start_cluster & 0xffff);
+	if (mydata->fatsize == 32)
+		dentptr->starthi =
+			cpu_to_le16((start_cluster & 0xffff0000) >> 16);
+	dentptr->start = cpu_to_le16(start_cluster & 0xffff);
 }
 
 /*
  * Fill dir_entry
  */
 static void fill_dentry(fsdata *mydata, dir_entry *dentptr,
-    const char *filename, __u32 start_cluster, __u32 size, __u8 attr)
+	const char *filename, __u32 start_cluster, __u32 size, __u8 attr)
 {
-    set_start_cluster(mydata, dentptr, start_cluster);
-    dentptr->size = cpu_to_le32(size);
+	set_start_cluster(mydata, dentptr, start_cluster);
+	dentptr->size = cpu_to_le32(size);
 
-    dentptr->attr = attr;
+	dentptr->attr = attr;
 
-    set_name(dentptr, filename);
+	set_name(dentptr, filename);
 }
 
 /*
@@ -860,23 +860,23 @@ static void fill_dentry(fsdata *mydata, dir_entry *dentptr,
  */
 static int check_overflow(fsdata *mydata, __u32 clustnum, loff_t size)
 {
-    __u32 startsect, sect_num, offset;
+	__u32 startsect, sect_num, offset;
 
-    if (clustnum > 0) {
-        startsect = mydata->data_begin +
-                clustnum * mydata->clust_size;
-    } else {
-        startsect = mydata->rootdir_sect;
-    }
+	if (clustnum > 0) {
+		startsect = mydata->data_begin +
+				clustnum * mydata->clust_size;
+	} else {
+		startsect = mydata->rootdir_sect;
+	}
 
-    sect_num = div_u64_rem(size, mydata->sect_size, &offset);
+	sect_num = div_u64_rem(size, mydata->sect_size, &offset);
 
-    if (offset != 0)
-        sect_num++;
+	if (offset != 0)
+		sect_num++;
 
-    if (startsect + sect_num > cur_part_info.start + total_sector)
-        return -1;
-    return 0;
+	if (startsect + sect_num > cur_part_info.start + total_sector)
+		return -1;
+	return 0;
 }
 
 /*
@@ -884,14 +884,14 @@ static int check_overflow(fsdata *mydata, __u32 clustnum, loff_t size)
  */
 static int is_next_clust(fsdata *mydata, dir_entry *dentptr)
 {
-    int cur_position;
+	int cur_position;
 
-    cur_position = (__u8 *)dentptr - get_dentfromdir_block;
+	cur_position = (__u8 *)dentptr - get_dentfromdir_block;
 
-    if (cur_position >= mydata->clust_size * mydata->sect_size)
-        return 1;
-    else
-        return 0;
+	if (cur_position >= mydata->clust_size * mydata->sect_size)
+		return 1;
+	else
+		return 0;
 }
 
 static dir_entry *empty_dentptr;
@@ -901,302 +901,302 @@ static dir_entry *empty_dentptr;
  * the new position for writing a directory entry will be returned
  */
 static dir_entry *find_directory_entry(fsdata *mydata, int startsect,
-    char *filename, dir_entry *retdent, __u32 start)
+	char *filename, dir_entry *retdent, __u32 start)
 {
-    __u32 curclust = (startsect - mydata->data_begin) / mydata->clust_size;
+	__u32 curclust = (startsect - mydata->data_begin) / mydata->clust_size;
 
-    debug("get_dentfromdir: %s\n", filename);
+	debug("get_dentfromdir: %s\n", filename);
 
-    while (1) {
-        dir_entry *dentptr;
+	while (1) {
+		dir_entry *dentptr;
 
-        int i;
+		int i;
 
-        if (get_cluster(mydata, curclust, get_dentfromdir_block,
-                mydata->clust_size * mydata->sect_size) != 0) {
-            printf("Error: reading directory block\n");
-            return NULL;
-        }
+		if (get_cluster(mydata, curclust, get_dentfromdir_block,
+			    mydata->clust_size * mydata->sect_size) != 0) {
+			printf("Error: reading directory block\n");
+			return NULL;
+		}
 
-        dentptr = (dir_entry *)get_dentfromdir_block;
+		dentptr = (dir_entry *)get_dentfromdir_block;
 
-        dir_curclust = curclust;
+		dir_curclust = curclust;
 
-        for (i = 0; i < DIRENTSPERCLUST; i++) {
-            char s_name[14], l_name[VFAT_MAXLEN_BYTES];
+		for (i = 0; i < DIRENTSPERCLUST; i++) {
+			char s_name[14], l_name[VFAT_MAXLEN_BYTES];
 
-            l_name[0] = '\0';
-            if (dentptr->name[0] == DELETED_FLAG) {
-                dentptr++;
-                if (is_next_clust(mydata, dentptr))
-                    break;
-                continue;
-            }
-            if ((dentptr->attr & ATTR_VOLUME)) {
-                if (vfat_enabled &&
-                    (dentptr->attr & ATTR_VFAT) &&
-                    (dentptr->name[0] & LAST_LONG_ENTRY_MASK)) {
-                    get_long_file_name(mydata, curclust,
-                             get_dentfromdir_block,
-                             &dentptr, l_name);
-                    debug("vfatname: |%s|\n", l_name);
-                } else {
-                    /* Volume label or VFAT entry */
-                    dentptr++;
-                    if (is_next_clust(mydata, dentptr))
-                        break;
-                    continue;
-                }
-            }
-            if (dentptr->name[0] == 0) {
-                debug("Dentname == NULL - %d\n", i);
-                empty_dentptr = dentptr;
-                return NULL;
-            }
+			l_name[0] = '\0';
+			if (dentptr->name[0] == DELETED_FLAG) {
+				dentptr++;
+				if (is_next_clust(mydata, dentptr))
+					break;
+				continue;
+			}
+			if ((dentptr->attr & ATTR_VOLUME)) {
+				if (vfat_enabled &&
+				    (dentptr->attr & ATTR_VFAT) &&
+				    (dentptr->name[0] & LAST_LONG_ENTRY_MASK)) {
+					get_long_file_name(mydata, curclust,
+						     get_dentfromdir_block,
+						     &dentptr, l_name);
+					debug("vfatname: |%s|\n", l_name);
+				} else {
+					/* Volume label or VFAT entry */
+					dentptr++;
+					if (is_next_clust(mydata, dentptr))
+						break;
+					continue;
+				}
+			}
+			if (dentptr->name[0] == 0) {
+				debug("Dentname == NULL - %d\n", i);
+				empty_dentptr = dentptr;
+				return NULL;
+			}
 
-            get_name(dentptr, s_name);
+			get_name(dentptr, s_name);
 
-            if (strcmp(filename, s_name)
-                && strcmp(filename, l_name)) {
-                debug("Mismatch: |%s|%s|\n",
-                    s_name, l_name);
-                dentptr++;
-                if (is_next_clust(mydata, dentptr))
-                    break;
-                continue;
-            }
+			if (strcmp(filename, s_name)
+			    && strcmp(filename, l_name)) {
+				debug("Mismatch: |%s|%s|\n",
+					s_name, l_name);
+				dentptr++;
+				if (is_next_clust(mydata, dentptr))
+					break;
+				continue;
+			}
 
-            memcpy(retdent, dentptr, sizeof(dir_entry));
+			memcpy(retdent, dentptr, sizeof(dir_entry));
 
-            debug("DentName: %s", s_name);
-            debug(", start: 0x%x", START(dentptr));
-            debug(", size:  0x%x %s\n",
-                  FAT2CPU32(dentptr->size),
-                  (dentptr->attr & ATTR_DIR) ?
-                  "(DIR)" : "");
+			debug("DentName: %s", s_name);
+			debug(", start: 0x%x", START(dentptr));
+			debug(", size:  0x%x %s\n",
+			      FAT2CPU32(dentptr->size),
+			      (dentptr->attr & ATTR_DIR) ?
+			      "(DIR)" : "");
 
-            return dentptr;
-        }
+			return dentptr;
+		}
 
-        /*
-         * In FAT16/12, the root dir is locate before data area, shows
-         * in following:
-         * -------------------------------------------------------------
-         * | Boot | FAT1 & 2 | Root dir | Data (start from cluster #2) |
-         * -------------------------------------------------------------
-         *
-         * As a result if curclust is in Root dir, it is a negative
-         * number or 0, 1.
-         *
-         */
-        if (mydata->fatsize != 32 && (int)curclust <= 1) {
-            /* Current clust is in root dir, set to next clust */
-            curclust++;
-            if ((int)curclust <= 1)
-                continue;   /* continue to find */
+		/*
+		 * In FAT16/12, the root dir is locate before data area, shows
+		 * in following:
+		 * -------------------------------------------------------------
+		 * | Boot | FAT1 & 2 | Root dir | Data (start from cluster #2) |
+		 * -------------------------------------------------------------
+		 *
+		 * As a result if curclust is in Root dir, it is a negative
+		 * number or 0, 1.
+		 *
+		 */
+		if (mydata->fatsize != 32 && (int)curclust <= 1) {
+			/* Current clust is in root dir, set to next clust */
+			curclust++;
+			if ((int)curclust <= 1)
+				continue;	/* continue to find */
 
-            /* Reach the end of root dir */
-            empty_dentptr = dentptr;
-            return NULL;
-        }
+			/* Reach the end of root dir */
+			empty_dentptr = dentptr;
+			return NULL;
+		}
 
-        curclust = get_fatent_value(mydata, dir_curclust);
-        if (IS_LAST_CLUST(curclust, mydata->fatsize)) {
-            empty_dentptr = dentptr;
-            return NULL;
-        }
-        if (CHECK_CLUST(curclust, mydata->fatsize)) {
-            debug("curclust: 0x%x\n", curclust);
-            debug("Invalid FAT entry\n");
-            return NULL;
-        }
-    }
+		curclust = get_fatent_value(mydata, dir_curclust);
+		if (IS_LAST_CLUST(curclust, mydata->fatsize)) {
+			empty_dentptr = dentptr;
+			return NULL;
+		}
+		if (CHECK_CLUST(curclust, mydata->fatsize)) {
+			debug("curclust: 0x%x\n", curclust);
+			debug("Invalid FAT entry\n");
+			return NULL;
+		}
+	}
 
-    return NULL;
+	return NULL;
 }
 
 static int do_fat_write(const char *filename, void *buffer, loff_t size,
-            loff_t *actwrite)
+			loff_t *actwrite)
 {
-    dir_entry *dentptr, *retdent;
-    __u32 startsect;
-    __u32 start_cluster;
-    boot_sector bs;
-    volume_info volinfo;
-    fsdata datablock;
-    fsdata *mydata = &datablock;
-    int cursect;
-    int ret = -1, name_len;
-    char l_filename[VFAT_MAXLEN_BYTES];
+	dir_entry *dentptr, *retdent;
+	__u32 startsect;
+	__u32 start_cluster;
+	boot_sector bs;
+	volume_info volinfo;
+	fsdata datablock;
+	fsdata *mydata = &datablock;
+	int cursect;
+	int ret = -1, name_len;
+	char l_filename[VFAT_MAXLEN_BYTES];
 
-    *actwrite = size;
-    dir_curclust = 0;
+	*actwrite = size;
+	dir_curclust = 0;
 
-    if (read_bootsectandvi(&bs, &volinfo, &mydata->fatsize)) {
-        debug("error: reading boot sector\n");
-        return -1;
-    }
+	if (read_bootsectandvi(&bs, &volinfo, &mydata->fatsize)) {
+		debug("error: reading boot sector\n");
+		return -1;
+	}
 
-    total_sector = bs.total_sect;
-    if (total_sector == 0)
-        total_sector = (int)cur_part_info.size; /* cast of lbaint_t */
+	total_sector = bs.total_sect;
+	if (total_sector == 0)
+		total_sector = (int)cur_part_info.size; /* cast of lbaint_t */
 
-    if (mydata->fatsize == 32)
-        mydata->fatlength = bs.fat32_length;
-    else
-        mydata->fatlength = bs.fat_length;
+	if (mydata->fatsize == 32)
+		mydata->fatlength = bs.fat32_length;
+	else
+		mydata->fatlength = bs.fat_length;
 
-    mydata->fat_sect = bs.reserved;
+	mydata->fat_sect = bs.reserved;
 
-    cursect = mydata->rootdir_sect
-        = mydata->fat_sect + mydata->fatlength * bs.fats;
-    num_of_fats = bs.fats;
+	cursect = mydata->rootdir_sect
+		= mydata->fat_sect + mydata->fatlength * bs.fats;
+	num_of_fats = bs.fats;
 
-    mydata->sect_size = (bs.sector_size[1] << 8) + bs.sector_size[0];
-    mydata->clust_size = bs.cluster_size;
+	mydata->sect_size = (bs.sector_size[1] << 8) + bs.sector_size[0];
+	mydata->clust_size = bs.cluster_size;
 
-    if (mydata->fatsize == 32) {
-        mydata->data_begin = mydata->rootdir_sect -
-                    (mydata->clust_size * 2);
-    } else {
-        int rootdir_size;
+	if (mydata->fatsize == 32) {
+		mydata->data_begin = mydata->rootdir_sect -
+					(mydata->clust_size * 2);
+	} else {
+		int rootdir_size;
 
-        rootdir_size = ((bs.dir_entries[1]  * (int)256 +
-                 bs.dir_entries[0]) *
-                 sizeof(dir_entry)) /
-                 mydata->sect_size;
-        mydata->data_begin = mydata->rootdir_sect +
-                    rootdir_size -
-                    (mydata->clust_size * 2);
-    }
+		rootdir_size = ((bs.dir_entries[1]  * (int)256 +
+				 bs.dir_entries[0]) *
+				 sizeof(dir_entry)) /
+				 mydata->sect_size;
+		mydata->data_begin = mydata->rootdir_sect +
+					rootdir_size -
+					(mydata->clust_size * 2);
+	}
 
-    mydata->fatbufnum = -1;
-    mydata->fat_dirty = 0;
-    mydata->fatbuf = memalign(ARCH_DMA_MINALIGN, FATBUFSIZE);
-    if (mydata->fatbuf == NULL) {
-        debug("Error: allocating memory\n");
-        return -1;
-    }
+	mydata->fatbufnum = -1;
+	mydata->fat_dirty = 0;
+	mydata->fatbuf = memalign(ARCH_DMA_MINALIGN, FATBUFSIZE);
+	if (mydata->fatbuf == NULL) {
+		debug("Error: allocating memory\n");
+		return -1;
+	}
 
-    if (disk_read(cursect,
-        (mydata->fatsize == 32) ?
-        (mydata->clust_size) :
-        PREFETCH_BLOCKS, do_fat_read_at_block) < 0) {
-        debug("Error: reading rootdir block\n");
-        goto exit;
-    }
-    dentptr = (dir_entry *) do_fat_read_at_block;
+	if (disk_read(cursect,
+		(mydata->fatsize == 32) ?
+		(mydata->clust_size) :
+		PREFETCH_BLOCKS, do_fat_read_at_block) < 0) {
+		debug("Error: reading rootdir block\n");
+		goto exit;
+	}
+	dentptr = (dir_entry *) do_fat_read_at_block;
 
-    name_len = strlen(filename);
-    if (name_len >= VFAT_MAXLEN_BYTES)
-        name_len = VFAT_MAXLEN_BYTES - 1;
+	name_len = strlen(filename);
+	if (name_len >= VFAT_MAXLEN_BYTES)
+		name_len = VFAT_MAXLEN_BYTES - 1;
 
-    memcpy(l_filename, filename, name_len);
-    l_filename[name_len] = 0; /* terminate the string */
-    downcase(l_filename);
+	memcpy(l_filename, filename, name_len);
+	l_filename[name_len] = 0; /* terminate the string */
+	downcase(l_filename);
 
-    startsect = mydata->rootdir_sect;
-    retdent = find_directory_entry(mydata, startsect,
-                l_filename, dentptr, 0);
-    if (retdent) {
-        /* Update file size and start_cluster in a directory entry */
-        retdent->size = cpu_to_le32(size);
-        start_cluster = START(retdent);
+	startsect = mydata->rootdir_sect;
+	retdent = find_directory_entry(mydata, startsect,
+				l_filename, dentptr, 0);
+	if (retdent) {
+		/* Update file size and start_cluster in a directory entry */
+		retdent->size = cpu_to_le32(size);
+		start_cluster = START(retdent);
 
-        if (start_cluster) {
-            if (size) {
-                ret = check_overflow(mydata, start_cluster,
-                            size);
-                if (ret) {
-                    printf("Error: %llu overflow\n", size);
-                    goto exit;
-                }
-            }
+		if (start_cluster) {
+			if (size) {
+				ret = check_overflow(mydata, start_cluster,
+							size);
+				if (ret) {
+					printf("Error: %llu overflow\n", size);
+					goto exit;
+				}
+			}
 
-            ret = clear_fatent(mydata, start_cluster);
-            if (ret) {
-                printf("Error: clearing FAT entries\n");
-                goto exit;
-            }
+			ret = clear_fatent(mydata, start_cluster);
+			if (ret) {
+				printf("Error: clearing FAT entries\n");
+				goto exit;
+			}
 
-            if (!size)
-                set_start_cluster(mydata, retdent, 0);
-        } else if (size) {
-            ret = start_cluster = find_empty_cluster(mydata);
-            if (ret < 0) {
-                printf("Error: finding empty cluster\n");
-                goto exit;
-            }
+			if (!size)
+				set_start_cluster(mydata, retdent, 0);
+		} else if (size) {
+			ret = start_cluster = find_empty_cluster(mydata);
+			if (ret < 0) {
+				printf("Error: finding empty cluster\n");
+				goto exit;
+			}
 
-            ret = check_overflow(mydata, start_cluster, size);
-            if (ret) {
-                printf("Error: %llu overflow\n", size);
-                goto exit;
-            }
+			ret = check_overflow(mydata, start_cluster, size);
+			if (ret) {
+				printf("Error: %llu overflow\n", size);
+				goto exit;
+			}
 
-            set_start_cluster(mydata, retdent, start_cluster);
-        }
-    } else {
-        /* Set short name to set alias checksum field in dir_slot */
-        set_name(empty_dentptr, filename);
-        fill_dir_slot(mydata, &empty_dentptr, filename);
+			set_start_cluster(mydata, retdent, start_cluster);
+		}
+	} else {
+		/* Set short name to set alias checksum field in dir_slot */
+		set_name(empty_dentptr, filename);
+		fill_dir_slot(mydata, &empty_dentptr, filename);
 
-        if (size) {
-            ret = start_cluster = find_empty_cluster(mydata);
-            if (ret < 0) {
-                printf("Error: finding empty cluster\n");
-                goto exit;
-            }
+		if (size) {
+			ret = start_cluster = find_empty_cluster(mydata);
+			if (ret < 0) {
+				printf("Error: finding empty cluster\n");
+				goto exit;
+			}
 
-            ret = check_overflow(mydata, start_cluster, size);
-            if (ret) {
-                printf("Error: %llu overflow\n", size);
-                goto exit;
-            }
-        } else {
-            start_cluster = 0;
-        }
+			ret = check_overflow(mydata, start_cluster, size);
+			if (ret) {
+				printf("Error: %llu overflow\n", size);
+				goto exit;
+			}
+		} else {
+			start_cluster = 0;
+		}
 
-        /* Set attribute as archieve for regular file */
-        fill_dentry(mydata, empty_dentptr, filename,
-            start_cluster, size, 0x20);
+		/* Set attribute as archieve for regular file */
+		fill_dentry(mydata, empty_dentptr, filename,
+			start_cluster, size, 0x20);
 
-        retdent = empty_dentptr;
-    }
+		retdent = empty_dentptr;
+	}
 
-    ret = set_contents(mydata, retdent, buffer, size, actwrite);
-    if (ret < 0) {
-        printf("Error: writing contents\n");
-        goto exit;
-    }
-    debug("attempt to write 0x%llx bytes\n", *actwrite);
+	ret = set_contents(mydata, retdent, buffer, size, actwrite);
+	if (ret < 0) {
+		printf("Error: writing contents\n");
+		goto exit;
+	}
+	debug("attempt to write 0x%llx bytes\n", *actwrite);
 
-    /* Flush fat buffer */
-    ret = flush_dirty_fat_buffer(mydata);
-    if (ret) {
-        printf("Error: flush fat buffer\n");
-        goto exit;
-    }
+	/* Flush fat buffer */
+	ret = flush_dirty_fat_buffer(mydata);
+	if (ret) {
+		printf("Error: flush fat buffer\n");
+		goto exit;
+	}
 
-    /* Write directory table to device */
-    ret = set_cluster(mydata, dir_curclust, get_dentfromdir_block,
-            mydata->clust_size * mydata->sect_size);
-    if (ret)
-        printf("Error: writing directory entry\n");
+	/* Write directory table to device */
+	ret = set_cluster(mydata, dir_curclust, get_dentfromdir_block,
+			mydata->clust_size * mydata->sect_size);
+	if (ret)
+		printf("Error: writing directory entry\n");
 
 exit:
-    free(mydata->fatbuf);
-    return ret;
+	free(mydata->fatbuf);
+	return ret;
 }
 
 int file_fat_write(const char *filename, void *buffer, loff_t offset,
-           loff_t maxsize, loff_t *actwrite)
+		   loff_t maxsize, loff_t *actwrite)
 {
-    if (offset != 0) {
-        printf("Error: non zero offset is currently not supported.\n");
-        return -1;
-    }
+	if (offset != 0) {
+		printf("Error: non zero offset is currently not supported.\n");
+		return -1;
+	}
 
-    printf("writing %s\n", filename);
-    return do_fat_write(filename, buffer, maxsize, actwrite);
+	printf("writing %s\n", filename);
+	return do_fat_write(filename, buffer, maxsize, actwrite);
 }

--- a/include/ext4fs.h
+++ b/include/ext4fs.h
@@ -135,7 +135,7 @@ int ext4_write_file(const char *filename, void *buf, loff_t offset, loff_t len,
 
 struct ext_filesystem *get_fs(void);
 int ext4fs_open(const char *filename, loff_t *len);
-int ext4fs_read(char *buf, loff_t len, loff_t *actread);
+int ext4fs_read(char *buf, loff_t offset, loff_t len, loff_t *actread);
 int ext4fs_mount(unsigned part_length);
 void ext4fs_close(void);
 void ext4fs_reinit_global(void);

--- a/include/image.h
+++ b/include/image.h
@@ -869,7 +869,7 @@ int bootz_setup(ulong image, ulong *start, ulong *end);
 
 /* image node */
 #define FIT_DATA_PROP		"data"
-#define FIT_DATA_OFFSET_PROP "data-offset"
+#define FIT_DATA_OFFSET_PROP	"data-offset"
 #define FIT_DATA_SIZE_PROP 	"data-size"
 #define FIT_TIMESTAMP_PROP	"timestamp"
 #define FIT_DESC_PROP		"description"
@@ -980,6 +980,8 @@ int fit_set_timestamp(void *fit, int noffset, time_t timestamp);
 int fit_add_verification_data(const char *keydir, void *keydest, void *fit,
 			      const char *comment, int require_keys);
 
+int fit_image_verify_with_data(const void *fit, int image_noffset,
+			       const void *data, size_t size);
 int fit_image_verify(const void *fit, int noffset);
 int fit_config_verify(const void *fit, int conf_noffset);
 int fit_all_image_verify(const void *fit);

--- a/include/image.h
+++ b/include/image.h
@@ -4,7 +4,7 @@
  * (C) Copyright 2000-2005
  * Wolfgang Denk, DENX Software Engineering, wd@denx.de.
  *
- * SPDX-License-Identifier: GPL-2.0+
+ * SPDX-License-Identifier:	GPL-2.0+
  ********************************************************************
  * NOTE: This header file defines an interface to U-Boot. Including
  * this (unmodified) header file in another file is considered normal
@@ -26,12 +26,12 @@ struct lmb;
 #include <sys/types.h>
 
 /* new uImage format support enabled on host */
-#define IMAGE_ENABLE_FIT    1
-#define IMAGE_ENABLE_OF_LIBFDT  1
-#define CONFIG_FIT_VERBOSE  1 /* enable fit_format_{error,warning}() */
+#define IMAGE_ENABLE_FIT	1
+#define IMAGE_ENABLE_OF_LIBFDT	1
+#define CONFIG_FIT_VERBOSE	1 /* enable fit_format_{error,warning}() */
 
-#define IMAGE_ENABLE_IGNORE 0
-#define IMAGE_INDENT_STRING ""
+#define IMAGE_ENABLE_IGNORE	0
+#define IMAGE_INDENT_STRING	""
 
 #else
 
@@ -40,11 +40,11 @@ struct lmb;
 #include <command.h>
 
 /* Take notice of the 'ignore' property for hashes */
-#define IMAGE_ENABLE_IGNORE 1
-#define IMAGE_INDENT_STRING "   "
+#define IMAGE_ENABLE_IGNORE	1
+#define IMAGE_INDENT_STRING	"   "
 
-#define IMAGE_ENABLE_FIT    CONFIG_IS_ENABLED(FIT)
-#define IMAGE_ENABLE_OF_LIBFDT  CONFIG_IS_ENABLED(OF_LIBFDT)
+#define IMAGE_ENABLE_FIT	CONFIG_IS_ENABLED(FIT)
+#define IMAGE_ENABLE_OF_LIBFDT	CONFIG_IS_ENABLED(OF_LIBFDT)
 
 #endif /* USE_HOSTCC */
 
@@ -54,26 +54,26 @@ struct lmb;
 #include <fdt_support.h>
 # ifdef CONFIG_SPL_BUILD
 #  ifdef CONFIG_SPL_CRC32_SUPPORT
-#   define IMAGE_ENABLE_CRC32   1
+#   define IMAGE_ENABLE_CRC32	1
 #  endif
 #  ifdef CONFIG_SPL_MD5_SUPPORT
-#   define IMAGE_ENABLE_MD5 1
+#   define IMAGE_ENABLE_MD5	1
 #  endif
 #  ifdef CONFIG_SPL_SHA1_SUPPORT
-#   define IMAGE_ENABLE_SHA1    1
+#   define IMAGE_ENABLE_SHA1	1
 #  endif
 #  ifdef CONFIG_SPL_SHA256_SUPPORT
-#   define IMAGE_ENABLE_SHA256  1
+#   define IMAGE_ENABLE_SHA256	1
 #  endif
 # else
-#  define CONFIG_CRC32      /* FIT images need CRC32 support */
-#  define CONFIG_MD5        /* and MD5 */
-#  define CONFIG_SHA1       /* and SHA1 */
-#  define CONFIG_SHA256     /* and SHA256 */
-#  define IMAGE_ENABLE_CRC32    1
-#  define IMAGE_ENABLE_MD5  1
-#  define IMAGE_ENABLE_SHA1 1
-#  define IMAGE_ENABLE_SHA256   1
+#  define CONFIG_CRC32		/* FIT images need CRC32 support */
+#  define CONFIG_MD5		/* and MD5 */
+#  define CONFIG_SHA1		/* and SHA1 */
+#  define CONFIG_SHA256		/* and SHA256 */
+#  define IMAGE_ENABLE_CRC32	1
+#  define IMAGE_ENABLE_MD5	1
+#  define IMAGE_ENABLE_SHA1	1
+#  define IMAGE_ENABLE_SHA256	1
 # endif
 
 #ifdef CONFIG_FIT_DISABLE_SHA256
@@ -82,54 +82,54 @@ struct lmb;
 #endif
 
 #ifndef IMAGE_ENABLE_CRC32
-#define IMAGE_ENABLE_CRC32  0
+#define IMAGE_ENABLE_CRC32	0
 #endif
 
 #ifndef IMAGE_ENABLE_MD5
-#define IMAGE_ENABLE_MD5    0
+#define IMAGE_ENABLE_MD5	0
 #endif
 
 #ifndef IMAGE_ENABLE_SHA1
-#define IMAGE_ENABLE_SHA1   0
+#define IMAGE_ENABLE_SHA1	0
 #endif
 
 #ifndef IMAGE_ENABLE_SHA256
-#define IMAGE_ENABLE_SHA256 0
+#define IMAGE_ENABLE_SHA256	0
 #endif
 
 #endif /* IMAGE_ENABLE_FIT */
 
 #ifdef CONFIG_SYS_BOOT_RAMDISK_HIGH
-# define IMAGE_ENABLE_RAMDISK_HIGH  1
+# define IMAGE_ENABLE_RAMDISK_HIGH	1
 #else
-# define IMAGE_ENABLE_RAMDISK_HIGH  0
+# define IMAGE_ENABLE_RAMDISK_HIGH	0
 #endif
 
 #ifdef CONFIG_SYS_BOOT_GET_CMDLINE
-# define IMAGE_BOOT_GET_CMDLINE     1
+# define IMAGE_BOOT_GET_CMDLINE		1
 #else
-# define IMAGE_BOOT_GET_CMDLINE     0
+# define IMAGE_BOOT_GET_CMDLINE		0
 #endif
 
 #ifdef CONFIG_OF_BOARD_SETUP
-# define IMAGE_OF_BOARD_SETUP       1
+# define IMAGE_OF_BOARD_SETUP		1
 #else
-# define IMAGE_OF_BOARD_SETUP       0
+# define IMAGE_OF_BOARD_SETUP		0
 #endif
 
 #ifdef CONFIG_OF_SYSTEM_SETUP
-# define IMAGE_OF_SYSTEM_SETUP  1
+# define IMAGE_OF_SYSTEM_SETUP	1
 #else
-# define IMAGE_OF_SYSTEM_SETUP  0
+# define IMAGE_OF_SYSTEM_SETUP	0
 #endif
 
 enum ih_category {
-    IH_ARCH,
-    IH_COMP,
-    IH_OS,
-    IH_TYPE,
+	IH_ARCH,
+	IH_COMP,
+	IH_OS,
+	IH_TYPE,
 
-    IH_COUNT,
+	IH_COUNT,
 };
 
 /*
@@ -139,33 +139,33 @@ enum ih_category {
  * Do not change values for backward compatibility.
  */
 enum {
-    IH_OS_INVALID       = 0,    /* Invalid OS   */
-    IH_OS_OPENBSD,          /* OpenBSD  */
-    IH_OS_NETBSD,           /* NetBSD   */
-    IH_OS_FREEBSD,          /* FreeBSD  */
-    IH_OS_4_4BSD,           /* 4.4BSD   */
-    IH_OS_LINUX,            /* Linux    */
-    IH_OS_SVR4,         /* SVR4     */
-    IH_OS_ESIX,         /* Esix     */
-    IH_OS_SOLARIS,          /* Solaris  */
-    IH_OS_IRIX,         /* Irix     */
-    IH_OS_SCO,          /* SCO      */
-    IH_OS_DELL,         /* Dell     */
-    IH_OS_NCR,          /* NCR      */
-    IH_OS_LYNXOS,           /* LynxOS   */
-    IH_OS_VXWORKS,          /* VxWorks  */
-    IH_OS_PSOS,         /* pSOS     */
-    IH_OS_QNX,          /* QNX      */
-    IH_OS_U_BOOT,           /* Firmware */
-    IH_OS_RTEMS,            /* RTEMS    */
-    IH_OS_ARTOS,            /* ARTOS    */
-    IH_OS_UNITY,            /* Unity OS */
-    IH_OS_INTEGRITY,        /* INTEGRITY    */
-    IH_OS_OSE,          /* OSE      */
-    IH_OS_PLAN9,            /* Plan 9   */
-    IH_OS_OPENRTOS,     /* OpenRTOS */
+	IH_OS_INVALID		= 0,	/* Invalid OS	*/
+	IH_OS_OPENBSD,			/* OpenBSD	*/
+	IH_OS_NETBSD,			/* NetBSD	*/
+	IH_OS_FREEBSD,			/* FreeBSD	*/
+	IH_OS_4_4BSD,			/* 4.4BSD	*/
+	IH_OS_LINUX,			/* Linux	*/
+	IH_OS_SVR4,			/* SVR4		*/
+	IH_OS_ESIX,			/* Esix		*/
+	IH_OS_SOLARIS,			/* Solaris	*/
+	IH_OS_IRIX,			/* Irix		*/
+	IH_OS_SCO,			/* SCO		*/
+	IH_OS_DELL,			/* Dell		*/
+	IH_OS_NCR,			/* NCR		*/
+	IH_OS_LYNXOS,			/* LynxOS	*/
+	IH_OS_VXWORKS,			/* VxWorks	*/
+	IH_OS_PSOS,			/* pSOS		*/
+	IH_OS_QNX,			/* QNX		*/
+	IH_OS_U_BOOT,			/* Firmware	*/
+	IH_OS_RTEMS,			/* RTEMS	*/
+	IH_OS_ARTOS,			/* ARTOS	*/
+	IH_OS_UNITY,			/* Unity OS	*/
+	IH_OS_INTEGRITY,		/* INTEGRITY	*/
+	IH_OS_OSE,			/* OSE		*/
+	IH_OS_PLAN9,			/* Plan 9	*/
+	IH_OS_OPENRTOS,		/* OpenRTOS	*/
 
-    IH_OS_COUNT,
+	IH_OS_COUNT,
 };
 
 /*
@@ -175,111 +175,111 @@ enum {
  * Do not change values for backward compatibility.
  */
 enum {
-    IH_ARCH_INVALID     = 0,    /* Invalid CPU  */
-    IH_ARCH_ALPHA,          /* Alpha    */
-    IH_ARCH_ARM,            /* ARM      */
-    IH_ARCH_I386,           /* Intel x86    */
-    IH_ARCH_IA64,           /* IA64     */
-    IH_ARCH_MIPS,           /* MIPS     */
-    IH_ARCH_MIPS64,         /* MIPS  64 Bit */
-    IH_ARCH_PPC,            /* PowerPC  */
-    IH_ARCH_S390,           /* IBM S390 */
-    IH_ARCH_SH,         /* SuperH   */
-    IH_ARCH_SPARC,          /* Sparc    */
-    IH_ARCH_SPARC64,        /* Sparc 64 Bit */
-    IH_ARCH_M68K,           /* M68K     */
-    IH_ARCH_NIOS,           /* Nios-32  */
-    IH_ARCH_MICROBLAZE,     /* MicroBlaze   */
-    IH_ARCH_NIOS2,          /* Nios-II  */
-    IH_ARCH_BLACKFIN,       /* Blackfin */
-    IH_ARCH_AVR32,          /* AVR32    */
-    IH_ARCH_ST200,          /* STMicroelectronics ST200  */
-    IH_ARCH_SANDBOX,        /* Sandbox architecture (test only) */
-    IH_ARCH_NDS32,          /* ANDES Technology - NDS32  */
-    IH_ARCH_OPENRISC,       /* OpenRISC 1000  */
-    IH_ARCH_ARM64,          /* ARM64    */
-    IH_ARCH_ARC,            /* Synopsys DesignWare ARC */
-    IH_ARCH_X86_64,         /* AMD x86_64, Intel and Via */
-    IH_ARCH_XTENSA,         /* Xtensa   */
+	IH_ARCH_INVALID		= 0,	/* Invalid CPU	*/
+	IH_ARCH_ALPHA,			/* Alpha	*/
+	IH_ARCH_ARM,			/* ARM		*/
+	IH_ARCH_I386,			/* Intel x86	*/
+	IH_ARCH_IA64,			/* IA64		*/
+	IH_ARCH_MIPS,			/* MIPS		*/
+	IH_ARCH_MIPS64,			/* MIPS	 64 Bit */
+	IH_ARCH_PPC,			/* PowerPC	*/
+	IH_ARCH_S390,			/* IBM S390	*/
+	IH_ARCH_SH,			/* SuperH	*/
+	IH_ARCH_SPARC,			/* Sparc	*/
+	IH_ARCH_SPARC64,		/* Sparc 64 Bit */
+	IH_ARCH_M68K,			/* M68K		*/
+	IH_ARCH_NIOS,			/* Nios-32	*/
+	IH_ARCH_MICROBLAZE,		/* MicroBlaze   */
+	IH_ARCH_NIOS2,			/* Nios-II	*/
+	IH_ARCH_BLACKFIN,		/* Blackfin	*/
+	IH_ARCH_AVR32,			/* AVR32	*/
+	IH_ARCH_ST200,			/* STMicroelectronics ST200  */
+	IH_ARCH_SANDBOX,		/* Sandbox architecture (test only) */
+	IH_ARCH_NDS32,			/* ANDES Technology - NDS32  */
+	IH_ARCH_OPENRISC,		/* OpenRISC 1000  */
+	IH_ARCH_ARM64,			/* ARM64	*/
+	IH_ARCH_ARC,			/* Synopsys DesignWare ARC */
+	IH_ARCH_X86_64,			/* AMD x86_64, Intel and Via */
+	IH_ARCH_XTENSA,			/* Xtensa	*/
 
-    IH_ARCH_COUNT,
+	IH_ARCH_COUNT,
 };
 
 /*
  * Image Types
  *
  * "Standalone Programs" are directly runnable in the environment
- *  provided by U-Boot; it is expected that (if they behave
- *  well) you can continue to work in U-Boot after return from
- *  the Standalone Program.
+ *	provided by U-Boot; it is expected that (if they behave
+ *	well) you can continue to work in U-Boot after return from
+ *	the Standalone Program.
  * "OS Kernel Images" are usually images of some Embedded OS which
- *  will take over control completely. Usually these programs
- *  will install their own set of exception handlers, device
- *  drivers, set up the MMU, etc. - this means, that you cannot
- *  expect to re-enter U-Boot except by resetting the CPU.
+ *	will take over control completely. Usually these programs
+ *	will install their own set of exception handlers, device
+ *	drivers, set up the MMU, etc. - this means, that you cannot
+ *	expect to re-enter U-Boot except by resetting the CPU.
  * "RAMDisk Images" are more or less just data blocks, and their
- *  parameters (address, size) are passed to an OS kernel that is
- *  being started.
+ *	parameters (address, size) are passed to an OS kernel that is
+ *	being started.
  * "Multi-File Images" contain several images, typically an OS
- *  (Linux) kernel image and one or more data images like
- *  RAMDisks. This construct is useful for instance when you want
- *  to boot over the network using BOOTP etc., where the boot
- *  server provides just a single image file, but you want to get
- *  for instance an OS kernel and a RAMDisk image.
+ *	(Linux) kernel image and one or more data images like
+ *	RAMDisks. This construct is useful for instance when you want
+ *	to boot over the network using BOOTP etc., where the boot
+ *	server provides just a single image file, but you want to get
+ *	for instance an OS kernel and a RAMDisk image.
  *
- *  "Multi-File Images" start with a list of image sizes, each
- *  image size (in bytes) specified by an "uint32_t" in network
- *  byte order. This list is terminated by an "(uint32_t)0".
- *  Immediately after the terminating 0 follow the images, one by
- *  one, all aligned on "uint32_t" boundaries (size rounded up to
- *  a multiple of 4 bytes - except for the last file).
+ *	"Multi-File Images" start with a list of image sizes, each
+ *	image size (in bytes) specified by an "uint32_t" in network
+ *	byte order. This list is terminated by an "(uint32_t)0".
+ *	Immediately after the terminating 0 follow the images, one by
+ *	one, all aligned on "uint32_t" boundaries (size rounded up to
+ *	a multiple of 4 bytes - except for the last file).
  *
  * "Firmware Images" are binary images containing firmware (like
- *  U-Boot or FPGA images) which usually will be programmed to
- *  flash memory.
+ *	U-Boot or FPGA images) which usually will be programmed to
+ *	flash memory.
  *
  * "Script files" are command sequences that will be executed by
- *  U-Boot's command interpreter; this feature is especially
- *  useful when you configure U-Boot to use a real shell (hush)
- *  as command interpreter (=> Shell Scripts).
+ *	U-Boot's command interpreter; this feature is especially
+ *	useful when you configure U-Boot to use a real shell (hush)
+ *	as command interpreter (=> Shell Scripts).
  *
  * The following are exposed to uImage header.
  * Do not change values for backward compatibility.
  */
 
 enum {
-    IH_TYPE_INVALID     = 0,    /* Invalid Image        */
-    IH_TYPE_STANDALONE,     /* Standalone Program       */
-    IH_TYPE_KERNEL,         /* OS Kernel Image      */
-    IH_TYPE_RAMDISK,        /* RAMDisk Image        */
-    IH_TYPE_MULTI,          /* Multi-File Image     */
-    IH_TYPE_FIRMWARE,       /* Firmware Image       */
-    IH_TYPE_SCRIPT,         /* Script file          */
-    IH_TYPE_FILESYSTEM,     /* Filesystem Image (any type)  */
-    IH_TYPE_FLATDT,         /* Binary Flat Device Tree Blob */
-    IH_TYPE_KWBIMAGE,       /* Kirkwood Boot Image      */
-    IH_TYPE_IMXIMAGE,       /* Freescale IMXBoot Image  */
-    IH_TYPE_UBLIMAGE,       /* Davinci UBL Image        */
-    IH_TYPE_OMAPIMAGE,      /* TI OMAP Config Header Image  */
-    IH_TYPE_AISIMAGE,       /* TI Davinci AIS Image     */
-    /* OS Kernel Image, can run from any load address */
-    IH_TYPE_KERNEL_NOLOAD,
-    IH_TYPE_PBLIMAGE,       /* Freescale PBL Boot Image */
-    IH_TYPE_MXSIMAGE,       /* Freescale MXSBoot Image  */
-    IH_TYPE_GPIMAGE,        /* TI Keystone GPHeader Image   */
-    IH_TYPE_ATMELIMAGE,     /* ATMEL ROM bootable Image */
-    IH_TYPE_SOCFPGAIMAGE,       /* Altera SOCFPGA Preloader */
-    IH_TYPE_X86_SETUP,      /* x86 setup.bin Image      */
-    IH_TYPE_LPC32XXIMAGE,       /* x86 setup.bin Image      */
-    IH_TYPE_LOADABLE,       /* A list of typeless images    */
-    IH_TYPE_RKIMAGE,        /* Rockchip Boot Image      */
-    IH_TYPE_RKSD,           /* Rockchip SD card     */
-    IH_TYPE_RKSPI,          /* Rockchip SPI image       */
-    IH_TYPE_ZYNQIMAGE,      /* Xilinx Zynq Boot Image */
-    IH_TYPE_ZYNQMPIMAGE,        /* Xilinx ZynqMP Boot Image */
-    IH_TYPE_FPGA,           /* FPGA Image */
+	IH_TYPE_INVALID		= 0,	/* Invalid Image		*/
+	IH_TYPE_STANDALONE,		/* Standalone Program		*/
+	IH_TYPE_KERNEL,			/* OS Kernel Image		*/
+	IH_TYPE_RAMDISK,		/* RAMDisk Image		*/
+	IH_TYPE_MULTI,			/* Multi-File Image		*/
+	IH_TYPE_FIRMWARE,		/* Firmware Image		*/
+	IH_TYPE_SCRIPT,			/* Script file			*/
+	IH_TYPE_FILESYSTEM,		/* Filesystem Image (any type)	*/
+	IH_TYPE_FLATDT,			/* Binary Flat Device Tree Blob	*/
+	IH_TYPE_KWBIMAGE,		/* Kirkwood Boot Image		*/
+	IH_TYPE_IMXIMAGE,		/* Freescale IMXBoot Image	*/
+	IH_TYPE_UBLIMAGE,		/* Davinci UBL Image		*/
+	IH_TYPE_OMAPIMAGE,		/* TI OMAP Config Header Image	*/
+	IH_TYPE_AISIMAGE,		/* TI Davinci AIS Image		*/
+	/* OS Kernel Image, can run from any load address */
+	IH_TYPE_KERNEL_NOLOAD,
+	IH_TYPE_PBLIMAGE,		/* Freescale PBL Boot Image	*/
+	IH_TYPE_MXSIMAGE,		/* Freescale MXSBoot Image	*/
+	IH_TYPE_GPIMAGE,		/* TI Keystone GPHeader Image	*/
+	IH_TYPE_ATMELIMAGE,		/* ATMEL ROM bootable Image	*/
+	IH_TYPE_SOCFPGAIMAGE,		/* Altera SOCFPGA Preloader	*/
+	IH_TYPE_X86_SETUP,		/* x86 setup.bin Image		*/
+	IH_TYPE_LPC32XXIMAGE,		/* x86 setup.bin Image		*/
+	IH_TYPE_LOADABLE,		/* A list of typeless images	*/
+	IH_TYPE_RKIMAGE,		/* Rockchip Boot Image		*/
+	IH_TYPE_RKSD,			/* Rockchip SD card		*/
+	IH_TYPE_RKSPI,			/* Rockchip SPI image		*/
+	IH_TYPE_ZYNQIMAGE,		/* Xilinx Zynq Boot Image */
+	IH_TYPE_ZYNQMPIMAGE,		/* Xilinx ZynqMP Boot Image */
+	IH_TYPE_FPGA,			/* FPGA Image */
 
-    IH_TYPE_COUNT,          /* Number of image types */
+	IH_TYPE_COUNT,			/* Number of image types */
 };
 
 /*
@@ -289,47 +289,47 @@ enum {
  * Do not change values for backward compatibility.
  */
 enum {
-    IH_COMP_NONE        = 0,    /*  No   Compression Used   */
-    IH_COMP_GZIP,           /* gzip  Compression Used   */
-    IH_COMP_BZIP2,          /* bzip2 Compression Used   */
-    IH_COMP_LZMA,           /* lzma  Compression Used   */
-    IH_COMP_LZO,            /* lzo   Compression Used   */
-    IH_COMP_LZ4,            /* lz4   Compression Used   */
+	IH_COMP_NONE		= 0,	/*  No	 Compression Used	*/
+	IH_COMP_GZIP,			/* gzip	 Compression Used	*/
+	IH_COMP_BZIP2,			/* bzip2 Compression Used	*/
+	IH_COMP_LZMA,			/* lzma  Compression Used	*/
+	IH_COMP_LZO,			/* lzo   Compression Used	*/
+	IH_COMP_LZ4,			/* lz4   Compression Used	*/
 
-    IH_COMP_COUNT,
+	IH_COMP_COUNT,
 };
 
-#define IH_MAGIC    0x27051956  /* Image Magic Number       */
-#define IH_NMLEN        32  /* Image Name Length        */
+#define IH_MAGIC	0x27051956	/* Image Magic Number		*/
+#define IH_NMLEN		32	/* Image Name Length		*/
 
 /* Reused from common.h */
-#define ROUND(a, b)     (((a) + (b) - 1) & ~((b) - 1))
+#define ROUND(a, b)		(((a) + (b) - 1) & ~((b) - 1))
 
 /*
  * Legacy format image header,
  * all data in network byte order (aka natural aka bigendian).
  */
 typedef struct image_header {
-    __be32      ih_magic;   /* Image Header Magic Number    */
-    __be32      ih_hcrc;    /* Image Header CRC Checksum    */
-    __be32      ih_time;    /* Image Creation Timestamp */
-    __be32      ih_size;    /* Image Data Size      */
-    __be32      ih_load;    /* Data  Load  Address      */
-    __be32      ih_ep;      /* Entry Point Address      */
-    __be32      ih_dcrc;    /* Image Data CRC Checksum  */
-    uint8_t     ih_os;      /* Operating System     */
-    uint8_t     ih_arch;    /* CPU architecture     */
-    uint8_t     ih_type;    /* Image Type           */
-    uint8_t     ih_comp;    /* Compression Type     */
-    uint8_t     ih_name[IH_NMLEN];  /* Image Name       */
+	__be32		ih_magic;	/* Image Header Magic Number	*/
+	__be32		ih_hcrc;	/* Image Header CRC Checksum	*/
+	__be32		ih_time;	/* Image Creation Timestamp	*/
+	__be32		ih_size;	/* Image Data Size		*/
+	__be32		ih_load;	/* Data	 Load  Address		*/
+	__be32		ih_ep;		/* Entry Point Address		*/
+	__be32		ih_dcrc;	/* Image Data CRC Checksum	*/
+	uint8_t		ih_os;		/* Operating System		*/
+	uint8_t		ih_arch;	/* CPU architecture		*/
+	uint8_t		ih_type;	/* Image Type			*/
+	uint8_t		ih_comp;	/* Compression Type		*/
+	uint8_t		ih_name[IH_NMLEN];	/* Image Name		*/
 } image_header_t;
 
 typedef struct image_info {
-    ulong       start, end;     /* start/end of blob */
-    ulong       image_start, image_len; /* start of image within blob, len of image */
-    ulong       load;           /* load addr for the image */
-    uint8_t     comp, type, os;     /* compression, type of image, os type */
-    uint8_t     arch;           /* CPU architecture */
+	ulong		start, end;		/* start/end of blob */
+	ulong		image_start, image_len; /* start of image within blob, len of image */
+	ulong		load;			/* load addr for the image */
+	uint8_t		comp, type, os;		/* compression, type of image, os type */
+	uint8_t		arch;			/* CPU architecture */
 } image_info_t;
 
 /*
@@ -337,68 +337,68 @@ typedef struct image_info {
  * routines.
  */
 typedef struct bootm_headers {
-    /*
-     * Legacy os image header, if it is a multi component image
-     * then boot_get_ramdisk() and get_fdt() will attempt to get
-     * data from second and third component accordingly.
-     */
-    image_header_t  *legacy_hdr_os;     /* image header pointer */
-    image_header_t  legacy_hdr_os_copy; /* header copy */
-    ulong       legacy_hdr_valid;
+	/*
+	 * Legacy os image header, if it is a multi component image
+	 * then boot_get_ramdisk() and get_fdt() will attempt to get
+	 * data from second and third component accordingly.
+	 */
+	image_header_t	*legacy_hdr_os;		/* image header pointer */
+	image_header_t	legacy_hdr_os_copy;	/* header copy */
+	ulong		legacy_hdr_valid;
 
 #if IMAGE_ENABLE_FIT
-    const char  *fit_uname_cfg; /* configuration node unit name */
+	const char	*fit_uname_cfg;	/* configuration node unit name */
 
-    void        *fit_hdr_os;    /* os FIT image header */
-    const char  *fit_uname_os;  /* os subimage node unit name */
-    int     fit_noffset_os; /* os subimage node offset */
+	void		*fit_hdr_os;	/* os FIT image header */
+	const char	*fit_uname_os;	/* os subimage node unit name */
+	int		fit_noffset_os;	/* os subimage node offset */
 
-    void        *fit_hdr_rd;    /* init ramdisk FIT image header */
-    const char  *fit_uname_rd;  /* init ramdisk subimage node unit name */
-    int     fit_noffset_rd; /* init ramdisk subimage node offset */
+	void		*fit_hdr_rd;	/* init ramdisk FIT image header */
+	const char	*fit_uname_rd;	/* init ramdisk subimage node unit name */
+	int		fit_noffset_rd;	/* init ramdisk subimage node offset */
 
-    void        *fit_hdr_fdt;   /* FDT blob FIT image header */
-    const char  *fit_uname_fdt; /* FDT blob subimage node unit name */
-    int     fit_noffset_fdt;/* FDT blob subimage node offset */
+	void		*fit_hdr_fdt;	/* FDT blob FIT image header */
+	const char	*fit_uname_fdt;	/* FDT blob subimage node unit name */
+	int		fit_noffset_fdt;/* FDT blob subimage node offset */
 
-    void        *fit_hdr_setup; /* x86 setup FIT image header */
-    const char  *fit_uname_setup; /* x86 setup subimage node name */
-    int     fit_noffset_setup;/* x86 setup subimage node offset */
+	void		*fit_hdr_setup;	/* x86 setup FIT image header */
+	const char	*fit_uname_setup; /* x86 setup subimage node name */
+	int		fit_noffset_setup;/* x86 setup subimage node offset */
 #endif
 
 #ifndef USE_HOSTCC
-    image_info_t    os;     /* os image info */
-    ulong       ep;     /* entry point of OS */
+	image_info_t	os;		/* os image info */
+	ulong		ep;		/* entry point of OS */
 
-    ulong       rd_start, rd_end;/* ramdisk start/end */
+	ulong		rd_start, rd_end;/* ramdisk start/end */
 
-    char        *ft_addr;   /* flat dev tree address */
-    ulong       ft_len;     /* length of flat device tree */
+	char		*ft_addr;	/* flat dev tree address */
+	ulong		ft_len;		/* length of flat device tree */
 
-    ulong       initrd_start;
-    ulong       initrd_end;
-    ulong       cmdline_start;
-    ulong       cmdline_end;
-    bd_t        *kbd;
+	ulong		initrd_start;
+	ulong		initrd_end;
+	ulong		cmdline_start;
+	ulong		cmdline_end;
+	bd_t		*kbd;
 #endif
 
-    int     verify;     /* getenv("verify")[0] != 'n' */
+	int		verify;		/* getenv("verify")[0] != 'n' */
 
-#define BOOTM_STATE_START   (0x00000001)
-#define BOOTM_STATE_FINDOS  (0x00000002)
-#define BOOTM_STATE_FINDOTHER   (0x00000004)
-#define BOOTM_STATE_LOADOS  (0x00000008)
-#define BOOTM_STATE_RAMDISK (0x00000010)
-#define BOOTM_STATE_FDT     (0x00000020)
-#define BOOTM_STATE_OS_CMDLINE  (0x00000040)
-#define BOOTM_STATE_OS_BD_T (0x00000080)
-#define BOOTM_STATE_OS_PREP (0x00000100)
-#define BOOTM_STATE_OS_FAKE_GO  (0x00000200)    /* 'Almost' run the OS */
-#define BOOTM_STATE_OS_GO   (0x00000400)
-    int     state;
+#define	BOOTM_STATE_START	(0x00000001)
+#define	BOOTM_STATE_FINDOS	(0x00000002)
+#define	BOOTM_STATE_FINDOTHER	(0x00000004)
+#define	BOOTM_STATE_LOADOS	(0x00000008)
+#define	BOOTM_STATE_RAMDISK	(0x00000010)
+#define	BOOTM_STATE_FDT		(0x00000020)
+#define	BOOTM_STATE_OS_CMDLINE	(0x00000040)
+#define	BOOTM_STATE_OS_BD_T	(0x00000080)
+#define	BOOTM_STATE_OS_PREP	(0x00000100)
+#define	BOOTM_STATE_OS_FAKE_GO	(0x00000200)	/* 'Almost' run the OS */
+#define	BOOTM_STATE_OS_GO	(0x00000400)
+	int		state;
 
 #ifdef CONFIG_LMB
-    struct lmb  lmb;        /* for memory mgmt */
+	struct lmb	lmb;		/* for memory mgmt */
 #endif
 } bootm_headers_t;
 
@@ -425,17 +425,17 @@ extern bootm_headers_t images;
 #define CHUNKSZ_SHA1 (64 * 1024)
 #endif
 
-#define uimage_to_cpu(x)        be32_to_cpu(x)
-#define cpu_to_uimage(x)        cpu_to_be32(x)
+#define uimage_to_cpu(x)		be32_to_cpu(x)
+#define cpu_to_uimage(x)		cpu_to_be32(x)
 
 /*
  * Translation table for entries of a specific type; used by
  * get_table_entry_id() and get_table_entry_name().
  */
 typedef struct table_entry {
-    int id;
-    char    *sname;     /* short (input) name to find table entry */
-    char    *lname;     /* long (output) name to print for messages */
+	int	id;
+	char	*sname;		/* short (input) name to find table entry */
+	char	*lname;		/* long (output) name to print for messages */
 } table_entry_t;
 
 /*
@@ -444,7 +444,7 @@ typedef struct table_entry {
  * found, it's id is returned to the caller.
  */
 int get_table_entry_id(const table_entry_t *table,
-        const char *table_name, const char *name);
+		const char *table_name, const char *name);
 /*
  * get_table_entry_name() scans the translation table trying to find
  * an entry that matches the given id. If a matching entry is found,
@@ -457,7 +457,7 @@ const char *genimg_get_os_name(uint8_t os);
 /**
  * genimg_get_os_short_name() - get the short name for an OS
  *
- * @param os    OS (IH_OS_...)
+ * @param os	OS (IH_OS_...)
  * @return OS short name, or "unknown" if unknown
  */
 const char *genimg_get_os_short_name(uint8_t comp);
@@ -467,7 +467,7 @@ const char *genimg_get_arch_name(uint8_t arch);
 /**
  * genimg_get_arch_short_name() - get the short name for an architecture
  *
- * @param arch  Architecture type (IH_ARCH_...)
+ * @param arch	Architecture type (IH_ARCH_...)
  * @return architecture short name, or "unknown" if unknown
  */
 const char *genimg_get_arch_short_name(uint8_t arch);
@@ -477,7 +477,7 @@ const char *genimg_get_type_name(uint8_t type);
 /**
  * genimg_get_type_short_name() - get the short name for an image type
  *
- * @param type  Image type (IH_TYPE_...)
+ * @param type	Image type (IH_TYPE_...)
  * @return image short name, or "unknown" if unknown
  */
 const char *genimg_get_type_short_name(uint8_t type);
@@ -487,7 +487,7 @@ const char *genimg_get_comp_name(uint8_t comp);
 /**
  * genimg_get_comp_short_name() - get the short name for a compression method
  *
- * @param comp  compression method (IH_COMP_...)
+ * @param comp	compression method (IH_COMP_...)
  * @return compression method short name, or "unknown" if unknown
  */
 const char *genimg_get_comp_short_name(uint8_t comp);
@@ -495,8 +495,8 @@ const char *genimg_get_comp_short_name(uint8_t comp);
 /**
  * genimg_get_cat_name() - Get the name of an item in a category
  *
- * @category:   Category of item
- * @id:     Item ID
+ * @category:	Category of item
+ * @id:		Item ID
  * @return name of item, or "Unknown ..." if unknown
  */
 const char *genimg_get_cat_name(enum ih_category category, uint id);
@@ -504,8 +504,8 @@ const char *genimg_get_cat_name(enum ih_category category, uint id);
 /**
  * genimg_get_cat_short_name() - Get the short name of an item in a category
  *
- * @category:   Category of item
- * @id:     Item ID
+ * @category:	Category of item
+ * @id:		Item ID
  * @return short name of item, or "Unknown ..." if unknown
  */
 const char *genimg_get_cat_short_name(enum ih_category category, uint id);
@@ -513,7 +513,7 @@ const char *genimg_get_cat_short_name(enum ih_category category, uint id);
 /**
  * genimg_get_cat_count() - Get the number of items in a category
  *
- * @category:   Category to check
+ * @category:	Category to check
  * @return the number of items in the category (IH_xxx_COUNT)
  */
 int genimg_get_cat_count(enum ih_category category);
@@ -533,7 +533,7 @@ int genimg_get_comp_id(const char *name);
 void genimg_print_size(uint32_t size);
 
 #if defined(CONFIG_TIMESTAMP) || defined(CONFIG_CMD_DATE) || \
-    defined(USE_HOSTCC)
+	defined(USE_HOSTCC)
 #define IMAGE_ENABLE_TIMESTAMP 1
 #else
 #define IMAGE_ENABLE_TIMESTAMP 0
@@ -542,36 +542,36 @@ void genimg_print_time(time_t timestamp);
 
 /* What to do with a image load address ('load = <> 'in the FIT) */
 enum fit_load_op {
-    FIT_LOAD_IGNORED,   /* Ignore load address */
-    FIT_LOAD_OPTIONAL,  /* Can be provided, but optional */
-    FIT_LOAD_OPTIONAL_NON_ZERO, /* Optional, a value of 0 is ignored */
-    FIT_LOAD_REQUIRED,  /* Must be provided */
+	FIT_LOAD_IGNORED,	/* Ignore load address */
+	FIT_LOAD_OPTIONAL,	/* Can be provided, but optional */
+	FIT_LOAD_OPTIONAL_NON_ZERO,	/* Optional, a value of 0 is ignored */
+	FIT_LOAD_REQUIRED,	/* Must be provided */
 };
 
 int boot_get_setup(bootm_headers_t *images, uint8_t arch, ulong *setup_start,
-           ulong *setup_len);
+		   ulong *setup_len);
 
 #ifndef USE_HOSTCC
 /* Image format types, returned by _get_format() routine */
-#define IMAGE_FORMAT_INVALID    0x00
+#define IMAGE_FORMAT_INVALID	0x00
 #if defined(CONFIG_IMAGE_FORMAT_LEGACY)
-#define IMAGE_FORMAT_LEGACY 0x01    /* legacy image_header based format */
+#define IMAGE_FORMAT_LEGACY	0x01	/* legacy image_header based format */
 #endif
-#define IMAGE_FORMAT_FIT    0x02    /* new, libfdt based format */
-#define IMAGE_FORMAT_ANDROID    0x03    /* Android boot image */
+#define IMAGE_FORMAT_FIT	0x02	/* new, libfdt based format */
+#define IMAGE_FORMAT_ANDROID	0x03	/* Android boot image */
 
 ulong genimg_get_kernel_addr_fit(char * const img_addr,
-                     const char **fit_uname_config,
-                     const char **fit_uname_kernel);
+			         const char **fit_uname_config,
+			         const char **fit_uname_kernel);
 ulong genimg_get_kernel_addr(char * const img_addr);
 int genimg_get_format(const void *img_addr);
 int genimg_has_config(bootm_headers_t *images);
 ulong genimg_get_image(ulong img_addr);
 
 int boot_get_fpga(int argc, char * const argv[], bootm_headers_t *images,
-        uint8_t arch, const ulong *ld_start, ulong * const ld_len);
+		uint8_t arch, const ulong *ld_start, ulong * const ld_len);
 int boot_get_ramdisk(int argc, char * const argv[], bootm_headers_t *images,
-        uint8_t arch, ulong *rd_start, ulong *rd_end);
+		uint8_t arch, ulong *rd_start, ulong *rd_end);
 
 /**
  * boot_get_loadable - routine to load a list of binaries to memory
@@ -595,11 +595,11 @@ int boot_get_ramdisk(int argc, char * const argv[], bootm_headers_t *images,
  *     error code, if an error occurs during fit_image_load
  */
 int boot_get_loadable(int argc, char * const argv[], bootm_headers_t *images,
-        uint8_t arch, const ulong *ld_start, ulong * const ld_len);
+		uint8_t arch, const ulong *ld_start, ulong * const ld_len);
 #endif /* !USE_HOSTCC */
 
 int boot_get_setup_fit(bootm_headers_t *images, uint8_t arch,
-               ulong *setup_start, ulong *setup_len);
+		       ulong *setup_start, ulong *setup_len);
 
 /**
  * fit_image_load() - load an image from a FIT
@@ -611,30 +611,30 @@ int boot_get_setup_fit(bootm_headers_t *images, uint8_t arch,
  *
  * The property to look up is defined by image_type.
  *
- * @param images    Boot images structure
- * @param addr      Address of FIT in memory
- * @param fit_unamep    On entry this is the requested image name
- *          (e.g. "kernel@1") or NULL to use the default. On exit
- *          points to the selected image name
- * @param fit_uname_configp On entry this is the requested configuration
- *          name (e.g. "conf@1") or NULL to use the default. On
- *          exit points to the selected configuration name.
- * @param arch      Expected architecture (IH_ARCH_...)
- * @param image_type    Required image type (IH_TYPE_...). If this is
- *          IH_TYPE_KERNEL then we allow IH_TYPE_KERNEL_NOLOAD
- *          also.
- * @param bootstage_id  ID of starting bootstage to use for progress updates.
- *          This will be added to the BOOTSTAGE_SUB values when
- *          calling bootstage_mark()
- * @param load_op   Decribes what to do with the load address
- * @param datap     Returns address of loaded image
- * @param lenp      Returns length of loaded image
+ * @param images	Boot images structure
+ * @param addr		Address of FIT in memory
+ * @param fit_unamep	On entry this is the requested image name
+ *			(e.g. "kernel@1") or NULL to use the default. On exit
+ *			points to the selected image name
+ * @param fit_uname_configp	On entry this is the requested configuration
+ *			name (e.g. "conf@1") or NULL to use the default. On
+ *			exit points to the selected configuration name.
+ * @param arch		Expected architecture (IH_ARCH_...)
+ * @param image_type	Required image type (IH_TYPE_...). If this is
+ *			IH_TYPE_KERNEL then we allow IH_TYPE_KERNEL_NOLOAD
+ *			also.
+ * @param bootstage_id	ID of starting bootstage to use for progress updates.
+ *			This will be added to the BOOTSTAGE_SUB values when
+ *			calling bootstage_mark()
+ * @param load_op	Decribes what to do with the load address
+ * @param datap		Returns address of loaded image
+ * @param lenp		Returns length of loaded image
  * @return node offset of image, or -ve error code on error
  */
 int fit_image_load(bootm_headers_t *images, ulong addr,
-           const char **fit_unamep, const char **fit_uname_configp,
-           int arch, int image_type, int bootstage_id,
-           enum fit_load_op load_op, ulong *datap, ulong *lenp);
+		   const char **fit_unamep, const char **fit_uname_configp,
+		   int arch, int image_type, int bootstage_id,
+		   enum fit_load_op load_op, ulong *datap, ulong *lenp);
 
 #ifndef USE_HOSTCC
 /**
@@ -647,34 +647,34 @@ int fit_image_load(bootm_headers_t *images, ulong addr,
  * For example, for something like:
  *
  * images {
- *  kernel@1 {
- *      ...
- *  };
+ *	kernel@1 {
+ *		...
+ *	};
  * };
  * configurations {
- *  conf@1 {
- *      kernel = "kernel@1";
- *  };
+ *	conf@1 {
+ *		kernel = "kernel@1";
+ *	};
  * };
  *
  * the function will return the node offset of the kernel@1 node, assuming
  * that conf@1 is the chosen configuration.
  *
- * @param images    Boot images structure
- * @param prop_name Property name to look up (FIT_..._PROP)
- * @param addr      Address of FIT in memory
+ * @param images	Boot images structure
+ * @param prop_name	Property name to look up (FIT_..._PROP)
+ * @param addr		Address of FIT in memory
  */
 int fit_get_node_from_config(bootm_headers_t *images, const char *prop_name,
-            ulong addr);
+			ulong addr);
 
 int boot_get_fdt(int flag, int argc, char * const argv[], uint8_t arch,
-         bootm_headers_t *images,
-         char **of_flat_tree, ulong *of_size);
+		 bootm_headers_t *images,
+		 char **of_flat_tree, ulong *of_size);
 void boot_fdt_add_mem_rsv_regions(struct lmb *lmb, void *fdt_blob);
 int boot_relocate_fdt(struct lmb *lmb, char **of_flat_tree, ulong *of_size);
 
 int boot_ramdisk_high(struct lmb *lmb, ulong rd_data, ulong rd_len,
-          ulong *initrd_start, ulong *initrd_end);
+		  ulong *initrd_start, ulong *initrd_end);
 int boot_get_cmdline(struct lmb *lmb, ulong *cmd_start, ulong *cmd_end);
 #ifdef CONFIG_SYS_BOOT_GET_KBD
 int boot_get_kbd(struct lmb *lmb, bd_t **kbd);
@@ -686,40 +686,40 @@ int boot_get_kbd(struct lmb *lmb, bd_t **kbd);
 /*******************************************************************/
 static inline uint32_t image_get_header_size(void)
 {
-    return (sizeof(image_header_t));
+	return (sizeof(image_header_t));
 }
 
 #define image_get_hdr_l(f) \
-    static inline uint32_t image_get_##f(const image_header_t *hdr) \
-    { \
-        return uimage_to_cpu(hdr->ih_##f); \
-    }
-image_get_hdr_l(magic)      /* image_get_magic */
-image_get_hdr_l(hcrc)       /* image_get_hcrc */
-image_get_hdr_l(time)       /* image_get_time */
-image_get_hdr_l(size)       /* image_get_size */
-image_get_hdr_l(load)       /* image_get_load */
-image_get_hdr_l(ep)     /* image_get_ep */
-image_get_hdr_l(dcrc)       /* image_get_dcrc */
+	static inline uint32_t image_get_##f(const image_header_t *hdr) \
+	{ \
+		return uimage_to_cpu(hdr->ih_##f); \
+	}
+image_get_hdr_l(magic)		/* image_get_magic */
+image_get_hdr_l(hcrc)		/* image_get_hcrc */
+image_get_hdr_l(time)		/* image_get_time */
+image_get_hdr_l(size)		/* image_get_size */
+image_get_hdr_l(load)		/* image_get_load */
+image_get_hdr_l(ep)		/* image_get_ep */
+image_get_hdr_l(dcrc)		/* image_get_dcrc */
 
 #define image_get_hdr_b(f) \
-    static inline uint8_t image_get_##f(const image_header_t *hdr) \
-    { \
-        return hdr->ih_##f; \
-    }
-image_get_hdr_b(os)     /* image_get_os */
-image_get_hdr_b(arch)       /* image_get_arch */
-image_get_hdr_b(type)       /* image_get_type */
-image_get_hdr_b(comp)       /* image_get_comp */
+	static inline uint8_t image_get_##f(const image_header_t *hdr) \
+	{ \
+		return hdr->ih_##f; \
+	}
+image_get_hdr_b(os)		/* image_get_os */
+image_get_hdr_b(arch)		/* image_get_arch */
+image_get_hdr_b(type)		/* image_get_type */
+image_get_hdr_b(comp)		/* image_get_comp */
 
 static inline char *image_get_name(const image_header_t *hdr)
 {
-    return (char *)hdr->ih_name;
+	return (char *)hdr->ih_name;
 }
 
 static inline uint32_t image_get_data_size(const image_header_t *hdr)
 {
-    return image_get_size(hdr);
+	return image_get_size(hdr);
 }
 
 /**
@@ -735,44 +735,44 @@ static inline uint32_t image_get_data_size(const image_header_t *hdr)
  */
 static inline ulong image_get_data(const image_header_t *hdr)
 {
-    return ((ulong)hdr + image_get_header_size());
+	return ((ulong)hdr + image_get_header_size());
 }
 
 static inline uint32_t image_get_image_size(const image_header_t *hdr)
 {
-    return (image_get_size(hdr) + image_get_header_size());
+	return (image_get_size(hdr) + image_get_header_size());
 }
 static inline ulong image_get_image_end(const image_header_t *hdr)
 {
-    return ((ulong)hdr + image_get_image_size(hdr));
+	return ((ulong)hdr + image_get_image_size(hdr));
 }
 
 #define image_set_hdr_l(f) \
-    static inline void image_set_##f(image_header_t *hdr, uint32_t val) \
-    { \
-        hdr->ih_##f = cpu_to_uimage(val); \
-    }
-image_set_hdr_l(magic)      /* image_set_magic */
-image_set_hdr_l(hcrc)       /* image_set_hcrc */
-image_set_hdr_l(time)       /* image_set_time */
-image_set_hdr_l(size)       /* image_set_size */
-image_set_hdr_l(load)       /* image_set_load */
-image_set_hdr_l(ep)     /* image_set_ep */
-image_set_hdr_l(dcrc)       /* image_set_dcrc */
+	static inline void image_set_##f(image_header_t *hdr, uint32_t val) \
+	{ \
+		hdr->ih_##f = cpu_to_uimage(val); \
+	}
+image_set_hdr_l(magic)		/* image_set_magic */
+image_set_hdr_l(hcrc)		/* image_set_hcrc */
+image_set_hdr_l(time)		/* image_set_time */
+image_set_hdr_l(size)		/* image_set_size */
+image_set_hdr_l(load)		/* image_set_load */
+image_set_hdr_l(ep)		/* image_set_ep */
+image_set_hdr_l(dcrc)		/* image_set_dcrc */
 
 #define image_set_hdr_b(f) \
-    static inline void image_set_##f(image_header_t *hdr, uint8_t val) \
-    { \
-        hdr->ih_##f = val; \
-    }
-image_set_hdr_b(os)     /* image_set_os */
-image_set_hdr_b(arch)       /* image_set_arch */
-image_set_hdr_b(type)       /* image_set_type */
-image_set_hdr_b(comp)       /* image_set_comp */
+	static inline void image_set_##f(image_header_t *hdr, uint8_t val) \
+	{ \
+		hdr->ih_##f = val; \
+	}
+image_set_hdr_b(os)		/* image_set_os */
+image_set_hdr_b(arch)		/* image_set_arch */
+image_set_hdr_b(type)		/* image_set_type */
+image_set_hdr_b(comp)		/* image_set_comp */
 
 static inline void image_set_name(image_header_t *hdr, const char *name)
 {
-    strncpy(image_get_name(hdr), name, IH_NMLEN);
+	strncpy(image_get_name(hdr), name, IH_NMLEN);
 }
 
 int image_check_hcrc(const image_header_t *hdr);
@@ -786,24 +786,24 @@ void memmove_wd(void *to, void *from, size_t len, ulong chunksz);
 
 static inline int image_check_magic(const image_header_t *hdr)
 {
-    return (image_get_magic(hdr) == IH_MAGIC);
+	return (image_get_magic(hdr) == IH_MAGIC);
 }
 static inline int image_check_type(const image_header_t *hdr, uint8_t type)
 {
-    return (image_get_type(hdr) == type);
+	return (image_get_type(hdr) == type);
 }
 static inline int image_check_arch(const image_header_t *hdr, uint8_t arch)
 {
-    return (image_get_arch(hdr) == arch);
+	return (image_get_arch(hdr) == arch);
 }
 static inline int image_check_os(const image_header_t *hdr, uint8_t os)
 {
-    return (image_get_os(hdr) == os);
+	return (image_get_os(hdr) == os);
 }
 
 ulong image_multi_count(const image_header_t *hdr);
 void image_multi_getimg(const image_header_t *hdr, ulong idx,
-            ulong *data, ulong *len);
+			ulong *data, ulong *len);
 
 void image_print_contents(const void *hdr);
 
@@ -813,7 +813,7 @@ static inline int image_check_target_arch(const image_header_t *hdr)
 #ifndef IH_ARCH_DEFAULT
 # error "please define IH_ARCH_DEFAULT in your arch asm/u-boot.h"
 #endif
-    return image_check_arch(hdr, IH_ARCH_DEFAULT);
+	return image_check_arch(hdr, IH_ARCH_DEFAULT);
 }
 #endif /* USE_HOSTCC */
 
@@ -822,14 +822,14 @@ static inline int image_check_target_arch(const image_header_t *hdr)
  *
  * This sets up properties in the FDT that is to be passed to linux.
  *
- * @images: Images information
- * @blob:   FDT to update
- * @of_size:    Size of the FDT
- * @lmb:    Points to logical memory block structure
+ * @images:	Images information
+ * @blob:	FDT to update
+ * @of_size:	Size of the FDT
+ * @lmb:	Points to logical memory block structure
  * @return 0 if ok, <0 on failure
  */
 int image_setup_libfdt(bootm_headers_t *images, void *blob,
-               int of_size, struct lmb *lmb);
+		       int of_size, struct lmb *lmb);
 
 /**
  * Set up the FDT to use for booting a kernel
@@ -837,7 +837,7 @@ int image_setup_libfdt(bootm_headers_t *images, void *blob,
  * This performs ramdisk setup, sets up the FDT if required, and adds
  * paramters to the FDT if libfdt is available.
  *
- * @param images    Images information
+ * @param images	Images information
  * @return 0 if ok, <0 on failure
  */
 int image_setup_linux(bootm_headers_t *images);
@@ -857,46 +857,46 @@ int bootz_setup(ulong image, ulong *start, ulong *end);
 /* New uImage format specific code (prefixed with fit_) */
 /*******************************************************************/
 
-#define FIT_IMAGES_PATH     "/images"
-#define FIT_CONFS_PATH      "/configurations"
+#define FIT_IMAGES_PATH		"/images"
+#define FIT_CONFS_PATH		"/configurations"
 
 /* hash/signature node */
-#define FIT_HASH_NODENAME   "hash"
-#define FIT_ALGO_PROP       "algo"
-#define FIT_VALUE_PROP      "value"
-#define FIT_IGNORE_PROP     "uboot-ignore"
-#define FIT_SIG_NODENAME    "signature"
+#define FIT_HASH_NODENAME	"hash"
+#define FIT_ALGO_PROP		"algo"
+#define FIT_VALUE_PROP		"value"
+#define FIT_IGNORE_PROP		"uboot-ignore"
+#define FIT_SIG_NODENAME	"signature"
 
 /* image node */
-#define FIT_DATA_PROP       "data"
+#define FIT_DATA_PROP		"data"
 #define FIT_DATA_OFFSET_PROP "data-offset"
-#define FIT_DATA_SIZE_PROP  "data-size"
-#define FIT_TIMESTAMP_PROP  "timestamp"
-#define FIT_DESC_PROP       "description"
-#define FIT_ARCH_PROP       "arch"
-#define FIT_TYPE_PROP       "type"
-#define FIT_OS_PROP     "os"
-#define FIT_COMP_PROP       "compression"
-#define FIT_ENTRY_PROP      "entry"
-#define FIT_LOAD_PROP       "load"
+#define FIT_DATA_SIZE_PROP 	"data-size"
+#define FIT_TIMESTAMP_PROP	"timestamp"
+#define FIT_DESC_PROP		"description"
+#define FIT_ARCH_PROP		"arch"
+#define FIT_TYPE_PROP		"type"
+#define FIT_OS_PROP		"os"
+#define FIT_COMP_PROP		"compression"
+#define FIT_ENTRY_PROP		"entry"
+#define FIT_LOAD_PROP		"load"
 
 /* configuration node */
-#define FIT_KERNEL_PROP     "kernel"
-#define FIT_RAMDISK_PROP    "ramdisk"
-#define FIT_FDT_PROP        "fdt"
-#define FIT_LOADABLE_PROP   "loadables"
-#define FIT_DEFAULT_PROP    "default"
-#define FIT_SETUP_PROP      "setup"
-#define FIT_FPGA_PROP       "fpga"
+#define FIT_KERNEL_PROP		"kernel"
+#define FIT_RAMDISK_PROP	"ramdisk"
+#define FIT_FDT_PROP		"fdt"
+#define FIT_LOADABLE_PROP	"loadables"
+#define FIT_DEFAULT_PROP	"default"
+#define FIT_SETUP_PROP		"setup"
+#define FIT_FPGA_PROP		"fpga"
 
-#define FIT_MAX_HASH_LEN    HASH_MAX_DIGEST_SIZE
+#define FIT_MAX_HASH_LEN	HASH_MAX_DIGEST_SIZE
 
 #if IMAGE_ENABLE_FIT
 /* cmdline argument format parsing */
 int fit_parse_conf(const char *spec, ulong addr_curr,
-        ulong *addr, const char **conf_name);
+		ulong *addr, const char **conf_name);
 int fit_parse_subimage(const char *spec, ulong addr_curr,
-        ulong *addr, const char **image_name);
+		ulong *addr, const char **image_name);
 
 int fit_get_subimage_count(const void *fit, int images_noffset);
 void fit_print_contents(const void *fit);
@@ -911,7 +911,7 @@ void fit_image_print(const void *fit, int noffset, const char *p);
  */
 static inline ulong fit_get_size(const void *fit)
 {
-    return fdt_totalsize(fit);
+	return fdt_totalsize(fit);
 }
 
 /**
@@ -932,9 +932,9 @@ ulong fit_get_end(const void *fit);
  *     pointer to node name, on success
  */
 static inline const char *fit_get_name(const void *fit_hdr,
-        int noffset, int *len)
+		int noffset, int *len)
 {
-    return fdt_get_name(fit_hdr, noffset, len);
+	return fdt_get_name(fit_hdr, noffset, len);
 }
 
 int fit_get_desc(const void *fit, int noffset, char **desc);
@@ -948,23 +948,23 @@ int fit_image_get_comp(const void *fit, int noffset, uint8_t *comp);
 int fit_image_get_load(const void *fit, int noffset, ulong *load);
 int fit_image_get_entry(const void *fit, int noffset, ulong *entry);
 int fit_image_get_data(const void *fit, int noffset,
-                const void **data, size_t *size);
+				const void **data, size_t *size);
 int fit_image_get_data_offset(const void *fit, int noffset, int *data_offset);
 int fit_image_get_data_size(const void *fit, int noffset, int *data_size);
 
 int fit_image_hash_get_algo(const void *fit, int noffset, char **algo);
 int fit_image_hash_get_value(const void *fit, int noffset, uint8_t **value,
-                int *value_len);
+				int *value_len);
 
 int fit_set_timestamp(void *fit, int noffset, time_t timestamp);
 
 /**
  * fit_add_verification_data() - add verification data to FIT image nodes
  *
- * @keydir: Directory containing keys
- * @kwydest:    FDT blob to write public key information to
- * @fit:    Pointer to the FIT format image header
- * @comment:    Comment to add to signature nodes
+ * @keydir:	Directory containing keys
+ * @kwydest:	FDT blob to write public key information to
+ * @fit:	Pointer to the FIT format image header
+ * @comment:	Comment to add to signature nodes
  * @require_keys: Mark all keys as 'required'
  *
  * Adds hash values for all component images in the FIT blob.
@@ -978,7 +978,7 @@ int fit_set_timestamp(void *fit, int noffset, time_t timestamp);
  *     libfdt error code, on failure
  */
 int fit_add_verification_data(const char *keydir, void *keydest, void *fit,
-                  const char *comment, int require_keys);
+			      const char *comment, int require_keys);
 
 int fit_image_verify(const void *fit, int noffset);
 int fit_config_verify(const void *fit, int conf_noffset);
@@ -994,9 +994,9 @@ int fit_conf_get_node(const void *fit, const char *conf_uname);
 
 /**
  * fit_conf_get_prop_node() - Get node refered to by a configuration
- * @fit:    FIT to check
- * @noffset:    Offset of conf@xxx node to check
- * @prop_name:  Property to read from the conf node
+ * @fit:	FIT to check
+ * @noffset:	Offset of conf@xxx node to check
+ * @prop_name:	Property to read from the conf node
  *
  * The conf@ nodes contain references to other nodes, using properties
  * like 'kernel = "kernel@1"'. Given such a property name (e.g. "kernel"),
@@ -1004,15 +1004,15 @@ int fit_conf_get_node(const void *fit, const char *conf_uname);
  * "/images/kernel@1".
  */
 int fit_conf_get_prop_node(const void *fit, int noffset,
-        const char *prop_name);
+		const char *prop_name);
 
 void fit_conf_print(const void *fit, int noffset, const char *p);
 
 int fit_check_ramdisk(const void *fit, int os_noffset,
-        uint8_t arch, int verify);
+		uint8_t arch, int verify);
 
 int calculate_hash(const void *data, int data_len, const char *algo,
-            uint8_t *value, int *value_len);
+			uint8_t *value, int *value_len);
 
 /*
  * At present we only support signing on the host, and verification on the
@@ -1020,49 +1020,49 @@ int calculate_hash(const void *data, int data_len, const char *algo,
  */
 #if defined(CONFIG_FIT_SIGNATURE)
 # ifdef USE_HOSTCC
-#  define IMAGE_ENABLE_SIGN 1
-#  define IMAGE_ENABLE_VERIFY   1
+#  define IMAGE_ENABLE_SIGN	1
+#  define IMAGE_ENABLE_VERIFY	1
 # include  <openssl/evp.h>
 #else
-#  define IMAGE_ENABLE_SIGN 0
-#  define IMAGE_ENABLE_VERIFY   1
+#  define IMAGE_ENABLE_SIGN	0
+#  define IMAGE_ENABLE_VERIFY	1
 # endif
 #else
-# define IMAGE_ENABLE_SIGN  0
-# define IMAGE_ENABLE_VERIFY    0
+# define IMAGE_ENABLE_SIGN	0
+# define IMAGE_ENABLE_VERIFY	0
 #endif
 
 #ifdef USE_HOSTCC
 void *image_get_host_blob(void);
 void image_set_host_blob(void *host_blob);
-# define gd_fdt_blob()      image_get_host_blob()
+# define gd_fdt_blob()		image_get_host_blob()
 #else
-# define gd_fdt_blob()      (gd->fdt_blob)
+# define gd_fdt_blob()		(gd->fdt_blob)
 #endif
 
 #ifdef CONFIG_FIT_BEST_MATCH
-#define IMAGE_ENABLE_BEST_MATCH 1
+#define IMAGE_ENABLE_BEST_MATCH	1
 #else
-#define IMAGE_ENABLE_BEST_MATCH 0
+#define IMAGE_ENABLE_BEST_MATCH	0
 #endif
 
 /* Information passed to the signing routines */
 struct image_sign_info {
-    const char *keydir;     /* Directory conaining keys */
-    const char *keyname;        /* Name of key to use */
-    void *fit;          /* Pointer to FIT blob */
-    int node_offset;        /* Offset of signature node */
-    struct image_sig_algo *algo;    /* Algorithm information */
-    const void *fdt_blob;       /* FDT containing public keys */
-    int required_keynode;       /* Node offset of key to use: -1=any */
-    const char *require_keys;   /* Value for 'required' property */
+	const char *keydir;		/* Directory conaining keys */
+	const char *keyname;		/* Name of key to use */
+	void *fit;			/* Pointer to FIT blob */
+	int node_offset;		/* Offset of signature node */
+	struct image_sig_algo *algo;	/* Algorithm information */
+	const void *fdt_blob;		/* FDT containing public keys */
+	int required_keynode;		/* Node offset of key to use: -1=any */
+	const char *require_keys;	/* Value for 'required' property */
 };
 #endif /* Allow struct image_region to always be defined for rsa.h */
 
 /* A part of an image, used for hashing */
 struct image_region {
-    const void *data;
-    int size;
+	const void *data;
+	int size;
 };
 
 #if IMAGE_ENABLE_FIT
@@ -1071,77 +1071,77 @@ struct image_region {
 # include <u-boot/rsa-checksum.h>
 #endif
 struct checksum_algo {
-    const char *name;
-    const int checksum_len;
-    const int pad_len;
+	const char *name;
+	const int checksum_len;
+	const int pad_len;
 #if IMAGE_ENABLE_SIGN
-    const EVP_MD *(*calculate_sign)(void);
+	const EVP_MD *(*calculate_sign)(void);
 #endif
-    int (*calculate)(const char *name,
-             const struct image_region region[],
-             int region_count, uint8_t *checksum);
-    const uint8_t *rsa_padding;
+	int (*calculate)(const char *name,
+			 const struct image_region region[],
+			 int region_count, uint8_t *checksum);
+	const uint8_t *rsa_padding;
 };
 
 struct image_sig_algo {
-    const char *name;       /* Name of algorithm */
+	const char *name;		/* Name of algorithm */
 
-    /**
-     * sign() - calculate and return signature for given input data
-     *
-     * @info:   Specifies key and FIT information
-     * @data:   Pointer to the input data
-     * @data_len:   Data length
-     * @sigp:   Set to an allocated buffer holding the signature
-     * @sig_len:    Set to length of the calculated hash
-     *
-     * This computes input data signature according to selected algorithm.
-     * Resulting signature value is placed in an allocated buffer, the
-     * pointer is returned as *sigp. The length of the calculated
-     * signature is returned via the sig_len pointer argument. The caller
-     * should free *sigp.
-     *
-     * @return: 0, on success, -ve on error
-     */
-    int (*sign)(struct image_sign_info *info,
-            const struct image_region region[],
-            int region_count, uint8_t **sigp, uint *sig_len);
+	/**
+	 * sign() - calculate and return signature for given input data
+	 *
+	 * @info:	Specifies key and FIT information
+	 * @data:	Pointer to the input data
+	 * @data_len:	Data length
+	 * @sigp:	Set to an allocated buffer holding the signature
+	 * @sig_len:	Set to length of the calculated hash
+	 *
+	 * This computes input data signature according to selected algorithm.
+	 * Resulting signature value is placed in an allocated buffer, the
+	 * pointer is returned as *sigp. The length of the calculated
+	 * signature is returned via the sig_len pointer argument. The caller
+	 * should free *sigp.
+	 *
+	 * @return: 0, on success, -ve on error
+	 */
+	int (*sign)(struct image_sign_info *info,
+		    const struct image_region region[],
+		    int region_count, uint8_t **sigp, uint *sig_len);
 
-    /**
-     * add_verify_data() - Add verification information to FDT
-     *
-     * Add public key information to the FDT node, suitable for
-     * verification at run-time. The information added depends on the
-     * algorithm being used.
-     *
-     * @info:   Specifies key and FIT information
-     * @keydest:    Destination FDT blob for public key data
-     * @return: 0, on success, -ve on error
-     */
-    int (*add_verify_data)(struct image_sign_info *info, void *keydest);
+	/**
+	 * add_verify_data() - Add verification information to FDT
+	 *
+	 * Add public key information to the FDT node, suitable for
+	 * verification at run-time. The information added depends on the
+	 * algorithm being used.
+	 *
+	 * @info:	Specifies key and FIT information
+	 * @keydest:	Destination FDT blob for public key data
+	 * @return: 0, on success, -ve on error
+	 */
+	int (*add_verify_data)(struct image_sign_info *info, void *keydest);
 
-    /**
-     * verify() - Verify a signature against some data
-     *
-     * @info:   Specifies key and FIT information
-     * @data:   Pointer to the input data
-     * @data_len:   Data length
-     * @sig:    Signature
-     * @sig_len:    Number of bytes in signature
-     * @return 0 if verified, -ve on error
-     */
-    int (*verify)(struct image_sign_info *info,
-              const struct image_region region[], int region_count,
-              uint8_t *sig, uint sig_len);
+	/**
+	 * verify() - Verify a signature against some data
+	 *
+	 * @info:	Specifies key and FIT information
+	 * @data:	Pointer to the input data
+	 * @data_len:	Data length
+	 * @sig:	Signature
+	 * @sig_len:	Number of bytes in signature
+	 * @return 0 if verified, -ve on error
+	 */
+	int (*verify)(struct image_sign_info *info,
+		      const struct image_region region[], int region_count,
+		      uint8_t *sig, uint sig_len);
 
-    /* pointer to checksum algorithm */
-    struct checksum_algo *checksum;
+	/* pointer to checksum algorithm */
+	struct checksum_algo *checksum;
 };
 
 /**
  * image_get_sig_algo() - Look up a signature algortihm
  *
- * @param name      Name of algorithm
+ * @param name		Name of algorithm
  * @return pointer to algorithm information, or NULL if not found
  */
 struct image_sig_algo *image_get_sig_algo(const char *name);
@@ -1149,38 +1149,38 @@ struct image_sig_algo *image_get_sig_algo(const char *name);
 /**
  * fit_image_verify_required_sigs() - Verify signatures marked as 'required'
  *
- * @fit:        FIT to check
- * @image_noffset:  Offset of image node to check
- * @data:       Image data to check
- * @size:       Size of image data
- * @sig_blob:       FDT containing public keys
- * @no_sigsp:       Returns 1 if no signatures were required, and
- *          therefore nothing was checked. The caller may wish
- *          to fall back to other mechanisms, or refuse to
- *          boot.
+ * @fit:		FIT to check
+ * @image_noffset:	Offset of image node to check
+ * @data:		Image data to check
+ * @size:		Size of image data
+ * @sig_blob:		FDT containing public keys
+ * @no_sigsp:		Returns 1 if no signatures were required, and
+ *			therefore nothing was checked. The caller may wish
+ *			to fall back to other mechanisms, or refuse to
+ *			boot.
  * @return 0 if all verified ok, <0 on error
  */
 int fit_image_verify_required_sigs(const void *fit, int image_noffset,
-        const char *data, size_t size, const void *sig_blob,
-        int *no_sigsp);
+		const char *data, size_t size, const void *sig_blob,
+		int *no_sigsp);
 
 /**
  * fit_image_check_sig() - Check a single image signature node
  *
- * @fit:        FIT to check
- * @noffset:        Offset of signature node to check
- * @data:       Image data to check
- * @size:       Size of image data
- * @required_keynode:   Offset in the control FDT of the required key node,
- *          if any. If this is given, then the image wil not
- *          pass verification unless that key is used. If this is
- *          -1 then any signature will do.
- * @err_msgp:       In the event of an error, this will be pointed to a
- *          help error string to display to the user.
+ * @fit:		FIT to check
+ * @noffset:		Offset of signature node to check
+ * @data:		Image data to check
+ * @size:		Size of image data
+ * @required_keynode:	Offset in the control FDT of the required key node,
+ *			if any. If this is given, then the image wil not
+ *			pass verification unless that key is used. If this is
+ *			-1 then any signature will do.
+ * @err_msgp:		In the event of an error, this will be pointed to a
+ *			help error string to display to the user.
  * @return 0 if all verified ok, <0 on error
  */
 int fit_image_check_sig(const void *fit, int noffset, const void *data,
-        size_t size, int required_keynode, char **err_msgp);
+		size_t size, int required_keynode, char **err_msgp);
 
 /**
  * fit_region_make_list() - Make a list of regions to hash
@@ -1189,34 +1189,34 @@ int fit_image_check_sig(const void *fit, int noffset, const void *data,
  * a list of regions (void *, size) for use by the signature creationg
  * and verification code.
  *
- * @fit:        FIT image to process
- * @fdt_regions:    Regions as returned by libfdt
- * @count:      Number of regions returned by libfdt
- * @region:     Place to put list of regions (NULL to allocate it)
+ * @fit:		FIT image to process
+ * @fdt_regions:	Regions as returned by libfdt
+ * @count:		Number of regions returned by libfdt
+ * @region:		Place to put list of regions (NULL to allocate it)
  * @return pointer to list of regions, or NULL if out of memory
  */
 struct image_region *fit_region_make_list(const void *fit,
-        struct fdt_region *fdt_regions, int count,
-        struct image_region *region);
+		struct fdt_region *fdt_regions, int count,
+		struct image_region *region);
 
 static inline int fit_image_check_target_arch(const void *fdt, int node)
 {
 #ifndef USE_HOSTCC
-    return fit_image_check_arch(fdt, node, IH_ARCH_DEFAULT);
+	return fit_image_check_arch(fdt, node, IH_ARCH_DEFAULT);
 #else
-    return 0;
+	return 0;
 #endif
 }
 
 #ifdef CONFIG_FIT_VERBOSE
-#define fit_unsupported(msg)    printf("! %s:%d " \
-                "FIT images not supported for '%s'\n", \
-                __FILE__, __LINE__, (msg))
+#define fit_unsupported(msg)	printf("! %s:%d " \
+				"FIT images not supported for '%s'\n", \
+				__FILE__, __LINE__, (msg))
 
-#define fit_unsupported_reset(msg)  printf("! %s:%d " \
-                "FIT images not supported for '%s' " \
-                "- must reset board to recover!\n", \
-                __FILE__, __LINE__, (msg))
+#define fit_unsupported_reset(msg)	printf("! %s:%d " \
+				"FIT images not supported for '%s' " \
+				"- must reset board to recover!\n", \
+				__FILE__, __LINE__, (msg))
 #else
 #define fit_unsupported(msg)
 #define fit_unsupported_reset(msg)
@@ -1227,9 +1227,9 @@ static inline int fit_image_check_target_arch(const void *fdt, int node)
 struct andr_img_hdr;
 int android_image_check_header(const struct andr_img_hdr *hdr);
 int android_image_get_kernel(const struct andr_img_hdr *hdr, int verify,
-                 ulong *os_data, ulong *os_len);
+			     ulong *os_data, ulong *os_len);
 int android_image_get_ramdisk(const struct andr_img_hdr *hdr,
-                  ulong *rd_data, ulong *rd_len);
+			      ulong *rd_data, ulong *rd_len);
 ulong android_image_get_end(const struct andr_img_hdr *hdr);
 ulong android_image_get_kload(const struct andr_img_hdr *hdr);
 void android_print_contents(const struct andr_img_hdr *hdr);
@@ -1266,4 +1266,4 @@ int board_fit_config_name_match(const char *name);
 void board_fit_image_post_process(void **p_image, size_t *p_size);
 #endif /* CONFIG_SPL_FIT_IMAGE_POST_PROCESS */
 
-#endif  /* __IMAGE_H__ */
+#endif	/* __IMAGE_H__ */

--- a/include/image.h
+++ b/include/image.h
@@ -4,7 +4,7 @@
  * (C) Copyright 2000-2005
  * Wolfgang Denk, DENX Software Engineering, wd@denx.de.
  *
- * SPDX-License-Identifier:	GPL-2.0+
+ * SPDX-License-Identifier: GPL-2.0+
  ********************************************************************
  * NOTE: This header file defines an interface to U-Boot. Including
  * this (unmodified) header file in another file is considered normal
@@ -26,12 +26,12 @@ struct lmb;
 #include <sys/types.h>
 
 /* new uImage format support enabled on host */
-#define IMAGE_ENABLE_FIT	1
-#define IMAGE_ENABLE_OF_LIBFDT	1
-#define CONFIG_FIT_VERBOSE	1 /* enable fit_format_{error,warning}() */
+#define IMAGE_ENABLE_FIT    1
+#define IMAGE_ENABLE_OF_LIBFDT  1
+#define CONFIG_FIT_VERBOSE  1 /* enable fit_format_{error,warning}() */
 
-#define IMAGE_ENABLE_IGNORE	0
-#define IMAGE_INDENT_STRING	""
+#define IMAGE_ENABLE_IGNORE 0
+#define IMAGE_INDENT_STRING ""
 
 #else
 
@@ -40,11 +40,11 @@ struct lmb;
 #include <command.h>
 
 /* Take notice of the 'ignore' property for hashes */
-#define IMAGE_ENABLE_IGNORE	1
-#define IMAGE_INDENT_STRING	"   "
+#define IMAGE_ENABLE_IGNORE 1
+#define IMAGE_INDENT_STRING "   "
 
-#define IMAGE_ENABLE_FIT	CONFIG_IS_ENABLED(FIT)
-#define IMAGE_ENABLE_OF_LIBFDT	CONFIG_IS_ENABLED(OF_LIBFDT)
+#define IMAGE_ENABLE_FIT    CONFIG_IS_ENABLED(FIT)
+#define IMAGE_ENABLE_OF_LIBFDT  CONFIG_IS_ENABLED(OF_LIBFDT)
 
 #endif /* USE_HOSTCC */
 
@@ -54,26 +54,26 @@ struct lmb;
 #include <fdt_support.h>
 # ifdef CONFIG_SPL_BUILD
 #  ifdef CONFIG_SPL_CRC32_SUPPORT
-#   define IMAGE_ENABLE_CRC32	1
+#   define IMAGE_ENABLE_CRC32   1
 #  endif
 #  ifdef CONFIG_SPL_MD5_SUPPORT
-#   define IMAGE_ENABLE_MD5	1
+#   define IMAGE_ENABLE_MD5 1
 #  endif
 #  ifdef CONFIG_SPL_SHA1_SUPPORT
-#   define IMAGE_ENABLE_SHA1	1
+#   define IMAGE_ENABLE_SHA1    1
 #  endif
 #  ifdef CONFIG_SPL_SHA256_SUPPORT
-#   define IMAGE_ENABLE_SHA256	1
+#   define IMAGE_ENABLE_SHA256  1
 #  endif
 # else
-#  define CONFIG_CRC32		/* FIT images need CRC32 support */
-#  define CONFIG_MD5		/* and MD5 */
-#  define CONFIG_SHA1		/* and SHA1 */
-#  define CONFIG_SHA256		/* and SHA256 */
-#  define IMAGE_ENABLE_CRC32	1
-#  define IMAGE_ENABLE_MD5	1
-#  define IMAGE_ENABLE_SHA1	1
-#  define IMAGE_ENABLE_SHA256	1
+#  define CONFIG_CRC32      /* FIT images need CRC32 support */
+#  define CONFIG_MD5        /* and MD5 */
+#  define CONFIG_SHA1       /* and SHA1 */
+#  define CONFIG_SHA256     /* and SHA256 */
+#  define IMAGE_ENABLE_CRC32    1
+#  define IMAGE_ENABLE_MD5  1
+#  define IMAGE_ENABLE_SHA1 1
+#  define IMAGE_ENABLE_SHA256   1
 # endif
 
 #ifdef CONFIG_FIT_DISABLE_SHA256
@@ -82,54 +82,54 @@ struct lmb;
 #endif
 
 #ifndef IMAGE_ENABLE_CRC32
-#define IMAGE_ENABLE_CRC32	0
+#define IMAGE_ENABLE_CRC32  0
 #endif
 
 #ifndef IMAGE_ENABLE_MD5
-#define IMAGE_ENABLE_MD5	0
+#define IMAGE_ENABLE_MD5    0
 #endif
 
 #ifndef IMAGE_ENABLE_SHA1
-#define IMAGE_ENABLE_SHA1	0
+#define IMAGE_ENABLE_SHA1   0
 #endif
 
 #ifndef IMAGE_ENABLE_SHA256
-#define IMAGE_ENABLE_SHA256	0
+#define IMAGE_ENABLE_SHA256 0
 #endif
 
 #endif /* IMAGE_ENABLE_FIT */
 
 #ifdef CONFIG_SYS_BOOT_RAMDISK_HIGH
-# define IMAGE_ENABLE_RAMDISK_HIGH	1
+# define IMAGE_ENABLE_RAMDISK_HIGH  1
 #else
-# define IMAGE_ENABLE_RAMDISK_HIGH	0
+# define IMAGE_ENABLE_RAMDISK_HIGH  0
 #endif
 
 #ifdef CONFIG_SYS_BOOT_GET_CMDLINE
-# define IMAGE_BOOT_GET_CMDLINE		1
+# define IMAGE_BOOT_GET_CMDLINE     1
 #else
-# define IMAGE_BOOT_GET_CMDLINE		0
+# define IMAGE_BOOT_GET_CMDLINE     0
 #endif
 
 #ifdef CONFIG_OF_BOARD_SETUP
-# define IMAGE_OF_BOARD_SETUP		1
+# define IMAGE_OF_BOARD_SETUP       1
 #else
-# define IMAGE_OF_BOARD_SETUP		0
+# define IMAGE_OF_BOARD_SETUP       0
 #endif
 
 #ifdef CONFIG_OF_SYSTEM_SETUP
-# define IMAGE_OF_SYSTEM_SETUP	1
+# define IMAGE_OF_SYSTEM_SETUP  1
 #else
-# define IMAGE_OF_SYSTEM_SETUP	0
+# define IMAGE_OF_SYSTEM_SETUP  0
 #endif
 
 enum ih_category {
-	IH_ARCH,
-	IH_COMP,
-	IH_OS,
-	IH_TYPE,
+    IH_ARCH,
+    IH_COMP,
+    IH_OS,
+    IH_TYPE,
 
-	IH_COUNT,
+    IH_COUNT,
 };
 
 /*
@@ -139,33 +139,33 @@ enum ih_category {
  * Do not change values for backward compatibility.
  */
 enum {
-	IH_OS_INVALID		= 0,	/* Invalid OS	*/
-	IH_OS_OPENBSD,			/* OpenBSD	*/
-	IH_OS_NETBSD,			/* NetBSD	*/
-	IH_OS_FREEBSD,			/* FreeBSD	*/
-	IH_OS_4_4BSD,			/* 4.4BSD	*/
-	IH_OS_LINUX,			/* Linux	*/
-	IH_OS_SVR4,			/* SVR4		*/
-	IH_OS_ESIX,			/* Esix		*/
-	IH_OS_SOLARIS,			/* Solaris	*/
-	IH_OS_IRIX,			/* Irix		*/
-	IH_OS_SCO,			/* SCO		*/
-	IH_OS_DELL,			/* Dell		*/
-	IH_OS_NCR,			/* NCR		*/
-	IH_OS_LYNXOS,			/* LynxOS	*/
-	IH_OS_VXWORKS,			/* VxWorks	*/
-	IH_OS_PSOS,			/* pSOS		*/
-	IH_OS_QNX,			/* QNX		*/
-	IH_OS_U_BOOT,			/* Firmware	*/
-	IH_OS_RTEMS,			/* RTEMS	*/
-	IH_OS_ARTOS,			/* ARTOS	*/
-	IH_OS_UNITY,			/* Unity OS	*/
-	IH_OS_INTEGRITY,		/* INTEGRITY	*/
-	IH_OS_OSE,			/* OSE		*/
-	IH_OS_PLAN9,			/* Plan 9	*/
-	IH_OS_OPENRTOS,		/* OpenRTOS	*/
+    IH_OS_INVALID       = 0,    /* Invalid OS   */
+    IH_OS_OPENBSD,          /* OpenBSD  */
+    IH_OS_NETBSD,           /* NetBSD   */
+    IH_OS_FREEBSD,          /* FreeBSD  */
+    IH_OS_4_4BSD,           /* 4.4BSD   */
+    IH_OS_LINUX,            /* Linux    */
+    IH_OS_SVR4,         /* SVR4     */
+    IH_OS_ESIX,         /* Esix     */
+    IH_OS_SOLARIS,          /* Solaris  */
+    IH_OS_IRIX,         /* Irix     */
+    IH_OS_SCO,          /* SCO      */
+    IH_OS_DELL,         /* Dell     */
+    IH_OS_NCR,          /* NCR      */
+    IH_OS_LYNXOS,           /* LynxOS   */
+    IH_OS_VXWORKS,          /* VxWorks  */
+    IH_OS_PSOS,         /* pSOS     */
+    IH_OS_QNX,          /* QNX      */
+    IH_OS_U_BOOT,           /* Firmware */
+    IH_OS_RTEMS,            /* RTEMS    */
+    IH_OS_ARTOS,            /* ARTOS    */
+    IH_OS_UNITY,            /* Unity OS */
+    IH_OS_INTEGRITY,        /* INTEGRITY    */
+    IH_OS_OSE,          /* OSE      */
+    IH_OS_PLAN9,            /* Plan 9   */
+    IH_OS_OPENRTOS,     /* OpenRTOS */
 
-	IH_OS_COUNT,
+    IH_OS_COUNT,
 };
 
 /*
@@ -175,111 +175,111 @@ enum {
  * Do not change values for backward compatibility.
  */
 enum {
-	IH_ARCH_INVALID		= 0,	/* Invalid CPU	*/
-	IH_ARCH_ALPHA,			/* Alpha	*/
-	IH_ARCH_ARM,			/* ARM		*/
-	IH_ARCH_I386,			/* Intel x86	*/
-	IH_ARCH_IA64,			/* IA64		*/
-	IH_ARCH_MIPS,			/* MIPS		*/
-	IH_ARCH_MIPS64,			/* MIPS	 64 Bit */
-	IH_ARCH_PPC,			/* PowerPC	*/
-	IH_ARCH_S390,			/* IBM S390	*/
-	IH_ARCH_SH,			/* SuperH	*/
-	IH_ARCH_SPARC,			/* Sparc	*/
-	IH_ARCH_SPARC64,		/* Sparc 64 Bit */
-	IH_ARCH_M68K,			/* M68K		*/
-	IH_ARCH_NIOS,			/* Nios-32	*/
-	IH_ARCH_MICROBLAZE,		/* MicroBlaze   */
-	IH_ARCH_NIOS2,			/* Nios-II	*/
-	IH_ARCH_BLACKFIN,		/* Blackfin	*/
-	IH_ARCH_AVR32,			/* AVR32	*/
-	IH_ARCH_ST200,			/* STMicroelectronics ST200  */
-	IH_ARCH_SANDBOX,		/* Sandbox architecture (test only) */
-	IH_ARCH_NDS32,			/* ANDES Technology - NDS32  */
-	IH_ARCH_OPENRISC,		/* OpenRISC 1000  */
-	IH_ARCH_ARM64,			/* ARM64	*/
-	IH_ARCH_ARC,			/* Synopsys DesignWare ARC */
-	IH_ARCH_X86_64,			/* AMD x86_64, Intel and Via */
-	IH_ARCH_XTENSA,			/* Xtensa	*/
+    IH_ARCH_INVALID     = 0,    /* Invalid CPU  */
+    IH_ARCH_ALPHA,          /* Alpha    */
+    IH_ARCH_ARM,            /* ARM      */
+    IH_ARCH_I386,           /* Intel x86    */
+    IH_ARCH_IA64,           /* IA64     */
+    IH_ARCH_MIPS,           /* MIPS     */
+    IH_ARCH_MIPS64,         /* MIPS  64 Bit */
+    IH_ARCH_PPC,            /* PowerPC  */
+    IH_ARCH_S390,           /* IBM S390 */
+    IH_ARCH_SH,         /* SuperH   */
+    IH_ARCH_SPARC,          /* Sparc    */
+    IH_ARCH_SPARC64,        /* Sparc 64 Bit */
+    IH_ARCH_M68K,           /* M68K     */
+    IH_ARCH_NIOS,           /* Nios-32  */
+    IH_ARCH_MICROBLAZE,     /* MicroBlaze   */
+    IH_ARCH_NIOS2,          /* Nios-II  */
+    IH_ARCH_BLACKFIN,       /* Blackfin */
+    IH_ARCH_AVR32,          /* AVR32    */
+    IH_ARCH_ST200,          /* STMicroelectronics ST200  */
+    IH_ARCH_SANDBOX,        /* Sandbox architecture (test only) */
+    IH_ARCH_NDS32,          /* ANDES Technology - NDS32  */
+    IH_ARCH_OPENRISC,       /* OpenRISC 1000  */
+    IH_ARCH_ARM64,          /* ARM64    */
+    IH_ARCH_ARC,            /* Synopsys DesignWare ARC */
+    IH_ARCH_X86_64,         /* AMD x86_64, Intel and Via */
+    IH_ARCH_XTENSA,         /* Xtensa   */
 
-	IH_ARCH_COUNT,
+    IH_ARCH_COUNT,
 };
 
 /*
  * Image Types
  *
  * "Standalone Programs" are directly runnable in the environment
- *	provided by U-Boot; it is expected that (if they behave
- *	well) you can continue to work in U-Boot after return from
- *	the Standalone Program.
+ *  provided by U-Boot; it is expected that (if they behave
+ *  well) you can continue to work in U-Boot after return from
+ *  the Standalone Program.
  * "OS Kernel Images" are usually images of some Embedded OS which
- *	will take over control completely. Usually these programs
- *	will install their own set of exception handlers, device
- *	drivers, set up the MMU, etc. - this means, that you cannot
- *	expect to re-enter U-Boot except by resetting the CPU.
+ *  will take over control completely. Usually these programs
+ *  will install their own set of exception handlers, device
+ *  drivers, set up the MMU, etc. - this means, that you cannot
+ *  expect to re-enter U-Boot except by resetting the CPU.
  * "RAMDisk Images" are more or less just data blocks, and their
- *	parameters (address, size) are passed to an OS kernel that is
- *	being started.
+ *  parameters (address, size) are passed to an OS kernel that is
+ *  being started.
  * "Multi-File Images" contain several images, typically an OS
- *	(Linux) kernel image and one or more data images like
- *	RAMDisks. This construct is useful for instance when you want
- *	to boot over the network using BOOTP etc., where the boot
- *	server provides just a single image file, but you want to get
- *	for instance an OS kernel and a RAMDisk image.
+ *  (Linux) kernel image and one or more data images like
+ *  RAMDisks. This construct is useful for instance when you want
+ *  to boot over the network using BOOTP etc., where the boot
+ *  server provides just a single image file, but you want to get
+ *  for instance an OS kernel and a RAMDisk image.
  *
- *	"Multi-File Images" start with a list of image sizes, each
- *	image size (in bytes) specified by an "uint32_t" in network
- *	byte order. This list is terminated by an "(uint32_t)0".
- *	Immediately after the terminating 0 follow the images, one by
- *	one, all aligned on "uint32_t" boundaries (size rounded up to
- *	a multiple of 4 bytes - except for the last file).
+ *  "Multi-File Images" start with a list of image sizes, each
+ *  image size (in bytes) specified by an "uint32_t" in network
+ *  byte order. This list is terminated by an "(uint32_t)0".
+ *  Immediately after the terminating 0 follow the images, one by
+ *  one, all aligned on "uint32_t" boundaries (size rounded up to
+ *  a multiple of 4 bytes - except for the last file).
  *
  * "Firmware Images" are binary images containing firmware (like
- *	U-Boot or FPGA images) which usually will be programmed to
- *	flash memory.
+ *  U-Boot or FPGA images) which usually will be programmed to
+ *  flash memory.
  *
  * "Script files" are command sequences that will be executed by
- *	U-Boot's command interpreter; this feature is especially
- *	useful when you configure U-Boot to use a real shell (hush)
- *	as command interpreter (=> Shell Scripts).
+ *  U-Boot's command interpreter; this feature is especially
+ *  useful when you configure U-Boot to use a real shell (hush)
+ *  as command interpreter (=> Shell Scripts).
  *
  * The following are exposed to uImage header.
  * Do not change values for backward compatibility.
  */
 
 enum {
-	IH_TYPE_INVALID		= 0,	/* Invalid Image		*/
-	IH_TYPE_STANDALONE,		/* Standalone Program		*/
-	IH_TYPE_KERNEL,			/* OS Kernel Image		*/
-	IH_TYPE_RAMDISK,		/* RAMDisk Image		*/
-	IH_TYPE_MULTI,			/* Multi-File Image		*/
-	IH_TYPE_FIRMWARE,		/* Firmware Image		*/
-	IH_TYPE_SCRIPT,			/* Script file			*/
-	IH_TYPE_FILESYSTEM,		/* Filesystem Image (any type)	*/
-	IH_TYPE_FLATDT,			/* Binary Flat Device Tree Blob	*/
-	IH_TYPE_KWBIMAGE,		/* Kirkwood Boot Image		*/
-	IH_TYPE_IMXIMAGE,		/* Freescale IMXBoot Image	*/
-	IH_TYPE_UBLIMAGE,		/* Davinci UBL Image		*/
-	IH_TYPE_OMAPIMAGE,		/* TI OMAP Config Header Image	*/
-	IH_TYPE_AISIMAGE,		/* TI Davinci AIS Image		*/
-	/* OS Kernel Image, can run from any load address */
-	IH_TYPE_KERNEL_NOLOAD,
-	IH_TYPE_PBLIMAGE,		/* Freescale PBL Boot Image	*/
-	IH_TYPE_MXSIMAGE,		/* Freescale MXSBoot Image	*/
-	IH_TYPE_GPIMAGE,		/* TI Keystone GPHeader Image	*/
-	IH_TYPE_ATMELIMAGE,		/* ATMEL ROM bootable Image	*/
-	IH_TYPE_SOCFPGAIMAGE,		/* Altera SOCFPGA Preloader	*/
-	IH_TYPE_X86_SETUP,		/* x86 setup.bin Image		*/
-	IH_TYPE_LPC32XXIMAGE,		/* x86 setup.bin Image		*/
-	IH_TYPE_LOADABLE,		/* A list of typeless images	*/
-	IH_TYPE_RKIMAGE,		/* Rockchip Boot Image		*/
-	IH_TYPE_RKSD,			/* Rockchip SD card		*/
-	IH_TYPE_RKSPI,			/* Rockchip SPI image		*/
-	IH_TYPE_ZYNQIMAGE,		/* Xilinx Zynq Boot Image */
-	IH_TYPE_ZYNQMPIMAGE,		/* Xilinx ZynqMP Boot Image */
-	IH_TYPE_FPGA,			/* FPGA Image */
+    IH_TYPE_INVALID     = 0,    /* Invalid Image        */
+    IH_TYPE_STANDALONE,     /* Standalone Program       */
+    IH_TYPE_KERNEL,         /* OS Kernel Image      */
+    IH_TYPE_RAMDISK,        /* RAMDisk Image        */
+    IH_TYPE_MULTI,          /* Multi-File Image     */
+    IH_TYPE_FIRMWARE,       /* Firmware Image       */
+    IH_TYPE_SCRIPT,         /* Script file          */
+    IH_TYPE_FILESYSTEM,     /* Filesystem Image (any type)  */
+    IH_TYPE_FLATDT,         /* Binary Flat Device Tree Blob */
+    IH_TYPE_KWBIMAGE,       /* Kirkwood Boot Image      */
+    IH_TYPE_IMXIMAGE,       /* Freescale IMXBoot Image  */
+    IH_TYPE_UBLIMAGE,       /* Davinci UBL Image        */
+    IH_TYPE_OMAPIMAGE,      /* TI OMAP Config Header Image  */
+    IH_TYPE_AISIMAGE,       /* TI Davinci AIS Image     */
+    /* OS Kernel Image, can run from any load address */
+    IH_TYPE_KERNEL_NOLOAD,
+    IH_TYPE_PBLIMAGE,       /* Freescale PBL Boot Image */
+    IH_TYPE_MXSIMAGE,       /* Freescale MXSBoot Image  */
+    IH_TYPE_GPIMAGE,        /* TI Keystone GPHeader Image   */
+    IH_TYPE_ATMELIMAGE,     /* ATMEL ROM bootable Image */
+    IH_TYPE_SOCFPGAIMAGE,       /* Altera SOCFPGA Preloader */
+    IH_TYPE_X86_SETUP,      /* x86 setup.bin Image      */
+    IH_TYPE_LPC32XXIMAGE,       /* x86 setup.bin Image      */
+    IH_TYPE_LOADABLE,       /* A list of typeless images    */
+    IH_TYPE_RKIMAGE,        /* Rockchip Boot Image      */
+    IH_TYPE_RKSD,           /* Rockchip SD card     */
+    IH_TYPE_RKSPI,          /* Rockchip SPI image       */
+    IH_TYPE_ZYNQIMAGE,      /* Xilinx Zynq Boot Image */
+    IH_TYPE_ZYNQMPIMAGE,        /* Xilinx ZynqMP Boot Image */
+    IH_TYPE_FPGA,           /* FPGA Image */
 
-	IH_TYPE_COUNT,			/* Number of image types */
+    IH_TYPE_COUNT,          /* Number of image types */
 };
 
 /*
@@ -289,47 +289,47 @@ enum {
  * Do not change values for backward compatibility.
  */
 enum {
-	IH_COMP_NONE		= 0,	/*  No	 Compression Used	*/
-	IH_COMP_GZIP,			/* gzip	 Compression Used	*/
-	IH_COMP_BZIP2,			/* bzip2 Compression Used	*/
-	IH_COMP_LZMA,			/* lzma  Compression Used	*/
-	IH_COMP_LZO,			/* lzo   Compression Used	*/
-	IH_COMP_LZ4,			/* lz4   Compression Used	*/
+    IH_COMP_NONE        = 0,    /*  No   Compression Used   */
+    IH_COMP_GZIP,           /* gzip  Compression Used   */
+    IH_COMP_BZIP2,          /* bzip2 Compression Used   */
+    IH_COMP_LZMA,           /* lzma  Compression Used   */
+    IH_COMP_LZO,            /* lzo   Compression Used   */
+    IH_COMP_LZ4,            /* lz4   Compression Used   */
 
-	IH_COMP_COUNT,
+    IH_COMP_COUNT,
 };
 
-#define IH_MAGIC	0x27051956	/* Image Magic Number		*/
-#define IH_NMLEN		32	/* Image Name Length		*/
+#define IH_MAGIC    0x27051956  /* Image Magic Number       */
+#define IH_NMLEN        32  /* Image Name Length        */
 
 /* Reused from common.h */
-#define ROUND(a, b)		(((a) + (b) - 1) & ~((b) - 1))
+#define ROUND(a, b)     (((a) + (b) - 1) & ~((b) - 1))
 
 /*
  * Legacy format image header,
  * all data in network byte order (aka natural aka bigendian).
  */
 typedef struct image_header {
-	__be32		ih_magic;	/* Image Header Magic Number	*/
-	__be32		ih_hcrc;	/* Image Header CRC Checksum	*/
-	__be32		ih_time;	/* Image Creation Timestamp	*/
-	__be32		ih_size;	/* Image Data Size		*/
-	__be32		ih_load;	/* Data	 Load  Address		*/
-	__be32		ih_ep;		/* Entry Point Address		*/
-	__be32		ih_dcrc;	/* Image Data CRC Checksum	*/
-	uint8_t		ih_os;		/* Operating System		*/
-	uint8_t		ih_arch;	/* CPU architecture		*/
-	uint8_t		ih_type;	/* Image Type			*/
-	uint8_t		ih_comp;	/* Compression Type		*/
-	uint8_t		ih_name[IH_NMLEN];	/* Image Name		*/
+    __be32      ih_magic;   /* Image Header Magic Number    */
+    __be32      ih_hcrc;    /* Image Header CRC Checksum    */
+    __be32      ih_time;    /* Image Creation Timestamp */
+    __be32      ih_size;    /* Image Data Size      */
+    __be32      ih_load;    /* Data  Load  Address      */
+    __be32      ih_ep;      /* Entry Point Address      */
+    __be32      ih_dcrc;    /* Image Data CRC Checksum  */
+    uint8_t     ih_os;      /* Operating System     */
+    uint8_t     ih_arch;    /* CPU architecture     */
+    uint8_t     ih_type;    /* Image Type           */
+    uint8_t     ih_comp;    /* Compression Type     */
+    uint8_t     ih_name[IH_NMLEN];  /* Image Name       */
 } image_header_t;
 
 typedef struct image_info {
-	ulong		start, end;		/* start/end of blob */
-	ulong		image_start, image_len; /* start of image within blob, len of image */
-	ulong		load;			/* load addr for the image */
-	uint8_t		comp, type, os;		/* compression, type of image, os type */
-	uint8_t		arch;			/* CPU architecture */
+    ulong       start, end;     /* start/end of blob */
+    ulong       image_start, image_len; /* start of image within blob, len of image */
+    ulong       load;           /* load addr for the image */
+    uint8_t     comp, type, os;     /* compression, type of image, os type */
+    uint8_t     arch;           /* CPU architecture */
 } image_info_t;
 
 /*
@@ -337,68 +337,68 @@ typedef struct image_info {
  * routines.
  */
 typedef struct bootm_headers {
-	/*
-	 * Legacy os image header, if it is a multi component image
-	 * then boot_get_ramdisk() and get_fdt() will attempt to get
-	 * data from second and third component accordingly.
-	 */
-	image_header_t	*legacy_hdr_os;		/* image header pointer */
-	image_header_t	legacy_hdr_os_copy;	/* header copy */
-	ulong		legacy_hdr_valid;
+    /*
+     * Legacy os image header, if it is a multi component image
+     * then boot_get_ramdisk() and get_fdt() will attempt to get
+     * data from second and third component accordingly.
+     */
+    image_header_t  *legacy_hdr_os;     /* image header pointer */
+    image_header_t  legacy_hdr_os_copy; /* header copy */
+    ulong       legacy_hdr_valid;
 
 #if IMAGE_ENABLE_FIT
-	const char	*fit_uname_cfg;	/* configuration node unit name */
+    const char  *fit_uname_cfg; /* configuration node unit name */
 
-	void		*fit_hdr_os;	/* os FIT image header */
-	const char	*fit_uname_os;	/* os subimage node unit name */
-	int		fit_noffset_os;	/* os subimage node offset */
+    void        *fit_hdr_os;    /* os FIT image header */
+    const char  *fit_uname_os;  /* os subimage node unit name */
+    int     fit_noffset_os; /* os subimage node offset */
 
-	void		*fit_hdr_rd;	/* init ramdisk FIT image header */
-	const char	*fit_uname_rd;	/* init ramdisk subimage node unit name */
-	int		fit_noffset_rd;	/* init ramdisk subimage node offset */
+    void        *fit_hdr_rd;    /* init ramdisk FIT image header */
+    const char  *fit_uname_rd;  /* init ramdisk subimage node unit name */
+    int     fit_noffset_rd; /* init ramdisk subimage node offset */
 
-	void		*fit_hdr_fdt;	/* FDT blob FIT image header */
-	const char	*fit_uname_fdt;	/* FDT blob subimage node unit name */
-	int		fit_noffset_fdt;/* FDT blob subimage node offset */
+    void        *fit_hdr_fdt;   /* FDT blob FIT image header */
+    const char  *fit_uname_fdt; /* FDT blob subimage node unit name */
+    int     fit_noffset_fdt;/* FDT blob subimage node offset */
 
-	void		*fit_hdr_setup;	/* x86 setup FIT image header */
-	const char	*fit_uname_setup; /* x86 setup subimage node name */
-	int		fit_noffset_setup;/* x86 setup subimage node offset */
+    void        *fit_hdr_setup; /* x86 setup FIT image header */
+    const char  *fit_uname_setup; /* x86 setup subimage node name */
+    int     fit_noffset_setup;/* x86 setup subimage node offset */
 #endif
 
 #ifndef USE_HOSTCC
-	image_info_t	os;		/* os image info */
-	ulong		ep;		/* entry point of OS */
+    image_info_t    os;     /* os image info */
+    ulong       ep;     /* entry point of OS */
 
-	ulong		rd_start, rd_end;/* ramdisk start/end */
+    ulong       rd_start, rd_end;/* ramdisk start/end */
 
-	char		*ft_addr;	/* flat dev tree address */
-	ulong		ft_len;		/* length of flat device tree */
+    char        *ft_addr;   /* flat dev tree address */
+    ulong       ft_len;     /* length of flat device tree */
 
-	ulong		initrd_start;
-	ulong		initrd_end;
-	ulong		cmdline_start;
-	ulong		cmdline_end;
-	bd_t		*kbd;
+    ulong       initrd_start;
+    ulong       initrd_end;
+    ulong       cmdline_start;
+    ulong       cmdline_end;
+    bd_t        *kbd;
 #endif
 
-	int		verify;		/* getenv("verify")[0] != 'n' */
+    int     verify;     /* getenv("verify")[0] != 'n' */
 
-#define	BOOTM_STATE_START	(0x00000001)
-#define	BOOTM_STATE_FINDOS	(0x00000002)
-#define	BOOTM_STATE_FINDOTHER	(0x00000004)
-#define	BOOTM_STATE_LOADOS	(0x00000008)
-#define	BOOTM_STATE_RAMDISK	(0x00000010)
-#define	BOOTM_STATE_FDT		(0x00000020)
-#define	BOOTM_STATE_OS_CMDLINE	(0x00000040)
-#define	BOOTM_STATE_OS_BD_T	(0x00000080)
-#define	BOOTM_STATE_OS_PREP	(0x00000100)
-#define	BOOTM_STATE_OS_FAKE_GO	(0x00000200)	/* 'Almost' run the OS */
-#define	BOOTM_STATE_OS_GO	(0x00000400)
-	int		state;
+#define BOOTM_STATE_START   (0x00000001)
+#define BOOTM_STATE_FINDOS  (0x00000002)
+#define BOOTM_STATE_FINDOTHER   (0x00000004)
+#define BOOTM_STATE_LOADOS  (0x00000008)
+#define BOOTM_STATE_RAMDISK (0x00000010)
+#define BOOTM_STATE_FDT     (0x00000020)
+#define BOOTM_STATE_OS_CMDLINE  (0x00000040)
+#define BOOTM_STATE_OS_BD_T (0x00000080)
+#define BOOTM_STATE_OS_PREP (0x00000100)
+#define BOOTM_STATE_OS_FAKE_GO  (0x00000200)    /* 'Almost' run the OS */
+#define BOOTM_STATE_OS_GO   (0x00000400)
+    int     state;
 
 #ifdef CONFIG_LMB
-	struct lmb	lmb;		/* for memory mgmt */
+    struct lmb  lmb;        /* for memory mgmt */
 #endif
 } bootm_headers_t;
 
@@ -425,17 +425,17 @@ extern bootm_headers_t images;
 #define CHUNKSZ_SHA1 (64 * 1024)
 #endif
 
-#define uimage_to_cpu(x)		be32_to_cpu(x)
-#define cpu_to_uimage(x)		cpu_to_be32(x)
+#define uimage_to_cpu(x)        be32_to_cpu(x)
+#define cpu_to_uimage(x)        cpu_to_be32(x)
 
 /*
  * Translation table for entries of a specific type; used by
  * get_table_entry_id() and get_table_entry_name().
  */
 typedef struct table_entry {
-	int	id;
-	char	*sname;		/* short (input) name to find table entry */
-	char	*lname;		/* long (output) name to print for messages */
+    int id;
+    char    *sname;     /* short (input) name to find table entry */
+    char    *lname;     /* long (output) name to print for messages */
 } table_entry_t;
 
 /*
@@ -444,7 +444,7 @@ typedef struct table_entry {
  * found, it's id is returned to the caller.
  */
 int get_table_entry_id(const table_entry_t *table,
-		const char *table_name, const char *name);
+        const char *table_name, const char *name);
 /*
  * get_table_entry_name() scans the translation table trying to find
  * an entry that matches the given id. If a matching entry is found,
@@ -457,7 +457,7 @@ const char *genimg_get_os_name(uint8_t os);
 /**
  * genimg_get_os_short_name() - get the short name for an OS
  *
- * @param os	OS (IH_OS_...)
+ * @param os    OS (IH_OS_...)
  * @return OS short name, or "unknown" if unknown
  */
 const char *genimg_get_os_short_name(uint8_t comp);
@@ -467,7 +467,7 @@ const char *genimg_get_arch_name(uint8_t arch);
 /**
  * genimg_get_arch_short_name() - get the short name for an architecture
  *
- * @param arch	Architecture type (IH_ARCH_...)
+ * @param arch  Architecture type (IH_ARCH_...)
  * @return architecture short name, or "unknown" if unknown
  */
 const char *genimg_get_arch_short_name(uint8_t arch);
@@ -477,7 +477,7 @@ const char *genimg_get_type_name(uint8_t type);
 /**
  * genimg_get_type_short_name() - get the short name for an image type
  *
- * @param type	Image type (IH_TYPE_...)
+ * @param type  Image type (IH_TYPE_...)
  * @return image short name, or "unknown" if unknown
  */
 const char *genimg_get_type_short_name(uint8_t type);
@@ -487,7 +487,7 @@ const char *genimg_get_comp_name(uint8_t comp);
 /**
  * genimg_get_comp_short_name() - get the short name for a compression method
  *
- * @param comp	compression method (IH_COMP_...)
+ * @param comp  compression method (IH_COMP_...)
  * @return compression method short name, or "unknown" if unknown
  */
 const char *genimg_get_comp_short_name(uint8_t comp);
@@ -495,8 +495,8 @@ const char *genimg_get_comp_short_name(uint8_t comp);
 /**
  * genimg_get_cat_name() - Get the name of an item in a category
  *
- * @category:	Category of item
- * @id:		Item ID
+ * @category:   Category of item
+ * @id:     Item ID
  * @return name of item, or "Unknown ..." if unknown
  */
 const char *genimg_get_cat_name(enum ih_category category, uint id);
@@ -504,8 +504,8 @@ const char *genimg_get_cat_name(enum ih_category category, uint id);
 /**
  * genimg_get_cat_short_name() - Get the short name of an item in a category
  *
- * @category:	Category of item
- * @id:		Item ID
+ * @category:   Category of item
+ * @id:     Item ID
  * @return short name of item, or "Unknown ..." if unknown
  */
 const char *genimg_get_cat_short_name(enum ih_category category, uint id);
@@ -513,7 +513,7 @@ const char *genimg_get_cat_short_name(enum ih_category category, uint id);
 /**
  * genimg_get_cat_count() - Get the number of items in a category
  *
- * @category:	Category to check
+ * @category:   Category to check
  * @return the number of items in the category (IH_xxx_COUNT)
  */
 int genimg_get_cat_count(enum ih_category category);
@@ -533,7 +533,7 @@ int genimg_get_comp_id(const char *name);
 void genimg_print_size(uint32_t size);
 
 #if defined(CONFIG_TIMESTAMP) || defined(CONFIG_CMD_DATE) || \
-	defined(USE_HOSTCC)
+    defined(USE_HOSTCC)
 #define IMAGE_ENABLE_TIMESTAMP 1
 #else
 #define IMAGE_ENABLE_TIMESTAMP 0
@@ -542,36 +542,36 @@ void genimg_print_time(time_t timestamp);
 
 /* What to do with a image load address ('load = <> 'in the FIT) */
 enum fit_load_op {
-	FIT_LOAD_IGNORED,	/* Ignore load address */
-	FIT_LOAD_OPTIONAL,	/* Can be provided, but optional */
-	FIT_LOAD_OPTIONAL_NON_ZERO,	/* Optional, a value of 0 is ignored */
-	FIT_LOAD_REQUIRED,	/* Must be provided */
+    FIT_LOAD_IGNORED,   /* Ignore load address */
+    FIT_LOAD_OPTIONAL,  /* Can be provided, but optional */
+    FIT_LOAD_OPTIONAL_NON_ZERO, /* Optional, a value of 0 is ignored */
+    FIT_LOAD_REQUIRED,  /* Must be provided */
 };
 
 int boot_get_setup(bootm_headers_t *images, uint8_t arch, ulong *setup_start,
-		   ulong *setup_len);
+           ulong *setup_len);
 
 #ifndef USE_HOSTCC
 /* Image format types, returned by _get_format() routine */
-#define IMAGE_FORMAT_INVALID	0x00
+#define IMAGE_FORMAT_INVALID    0x00
 #if defined(CONFIG_IMAGE_FORMAT_LEGACY)
-#define IMAGE_FORMAT_LEGACY	0x01	/* legacy image_header based format */
+#define IMAGE_FORMAT_LEGACY 0x01    /* legacy image_header based format */
 #endif
-#define IMAGE_FORMAT_FIT	0x02	/* new, libfdt based format */
-#define IMAGE_FORMAT_ANDROID	0x03	/* Android boot image */
+#define IMAGE_FORMAT_FIT    0x02    /* new, libfdt based format */
+#define IMAGE_FORMAT_ANDROID    0x03    /* Android boot image */
 
 ulong genimg_get_kernel_addr_fit(char * const img_addr,
-			         const char **fit_uname_config,
-			         const char **fit_uname_kernel);
+                     const char **fit_uname_config,
+                     const char **fit_uname_kernel);
 ulong genimg_get_kernel_addr(char * const img_addr);
 int genimg_get_format(const void *img_addr);
 int genimg_has_config(bootm_headers_t *images);
 ulong genimg_get_image(ulong img_addr);
 
 int boot_get_fpga(int argc, char * const argv[], bootm_headers_t *images,
-		uint8_t arch, const ulong *ld_start, ulong * const ld_len);
+        uint8_t arch, const ulong *ld_start, ulong * const ld_len);
 int boot_get_ramdisk(int argc, char * const argv[], bootm_headers_t *images,
-		uint8_t arch, ulong *rd_start, ulong *rd_end);
+        uint8_t arch, ulong *rd_start, ulong *rd_end);
 
 /**
  * boot_get_loadable - routine to load a list of binaries to memory
@@ -595,11 +595,11 @@ int boot_get_ramdisk(int argc, char * const argv[], bootm_headers_t *images,
  *     error code, if an error occurs during fit_image_load
  */
 int boot_get_loadable(int argc, char * const argv[], bootm_headers_t *images,
-		uint8_t arch, const ulong *ld_start, ulong * const ld_len);
+        uint8_t arch, const ulong *ld_start, ulong * const ld_len);
 #endif /* !USE_HOSTCC */
 
 int boot_get_setup_fit(bootm_headers_t *images, uint8_t arch,
-		       ulong *setup_start, ulong *setup_len);
+               ulong *setup_start, ulong *setup_len);
 
 /**
  * fit_image_load() - load an image from a FIT
@@ -611,30 +611,30 @@ int boot_get_setup_fit(bootm_headers_t *images, uint8_t arch,
  *
  * The property to look up is defined by image_type.
  *
- * @param images	Boot images structure
- * @param addr		Address of FIT in memory
- * @param fit_unamep	On entry this is the requested image name
- *			(e.g. "kernel@1") or NULL to use the default. On exit
- *			points to the selected image name
- * @param fit_uname_configp	On entry this is the requested configuration
- *			name (e.g. "conf@1") or NULL to use the default. On
- *			exit points to the selected configuration name.
- * @param arch		Expected architecture (IH_ARCH_...)
- * @param image_type	Required image type (IH_TYPE_...). If this is
- *			IH_TYPE_KERNEL then we allow IH_TYPE_KERNEL_NOLOAD
- *			also.
- * @param bootstage_id	ID of starting bootstage to use for progress updates.
- *			This will be added to the BOOTSTAGE_SUB values when
- *			calling bootstage_mark()
- * @param load_op	Decribes what to do with the load address
- * @param datap		Returns address of loaded image
- * @param lenp		Returns length of loaded image
+ * @param images    Boot images structure
+ * @param addr      Address of FIT in memory
+ * @param fit_unamep    On entry this is the requested image name
+ *          (e.g. "kernel@1") or NULL to use the default. On exit
+ *          points to the selected image name
+ * @param fit_uname_configp On entry this is the requested configuration
+ *          name (e.g. "conf@1") or NULL to use the default. On
+ *          exit points to the selected configuration name.
+ * @param arch      Expected architecture (IH_ARCH_...)
+ * @param image_type    Required image type (IH_TYPE_...). If this is
+ *          IH_TYPE_KERNEL then we allow IH_TYPE_KERNEL_NOLOAD
+ *          also.
+ * @param bootstage_id  ID of starting bootstage to use for progress updates.
+ *          This will be added to the BOOTSTAGE_SUB values when
+ *          calling bootstage_mark()
+ * @param load_op   Decribes what to do with the load address
+ * @param datap     Returns address of loaded image
+ * @param lenp      Returns length of loaded image
  * @return node offset of image, or -ve error code on error
  */
 int fit_image_load(bootm_headers_t *images, ulong addr,
-		   const char **fit_unamep, const char **fit_uname_configp,
-		   int arch, int image_type, int bootstage_id,
-		   enum fit_load_op load_op, ulong *datap, ulong *lenp);
+           const char **fit_unamep, const char **fit_uname_configp,
+           int arch, int image_type, int bootstage_id,
+           enum fit_load_op load_op, ulong *datap, ulong *lenp);
 
 #ifndef USE_HOSTCC
 /**
@@ -647,34 +647,34 @@ int fit_image_load(bootm_headers_t *images, ulong addr,
  * For example, for something like:
  *
  * images {
- *	kernel@1 {
- *		...
- *	};
+ *  kernel@1 {
+ *      ...
+ *  };
  * };
  * configurations {
- *	conf@1 {
- *		kernel = "kernel@1";
- *	};
+ *  conf@1 {
+ *      kernel = "kernel@1";
+ *  };
  * };
  *
  * the function will return the node offset of the kernel@1 node, assuming
  * that conf@1 is the chosen configuration.
  *
- * @param images	Boot images structure
- * @param prop_name	Property name to look up (FIT_..._PROP)
- * @param addr		Address of FIT in memory
+ * @param images    Boot images structure
+ * @param prop_name Property name to look up (FIT_..._PROP)
+ * @param addr      Address of FIT in memory
  */
 int fit_get_node_from_config(bootm_headers_t *images, const char *prop_name,
-			ulong addr);
+            ulong addr);
 
 int boot_get_fdt(int flag, int argc, char * const argv[], uint8_t arch,
-		 bootm_headers_t *images,
-		 char **of_flat_tree, ulong *of_size);
+         bootm_headers_t *images,
+         char **of_flat_tree, ulong *of_size);
 void boot_fdt_add_mem_rsv_regions(struct lmb *lmb, void *fdt_blob);
 int boot_relocate_fdt(struct lmb *lmb, char **of_flat_tree, ulong *of_size);
 
 int boot_ramdisk_high(struct lmb *lmb, ulong rd_data, ulong rd_len,
-		  ulong *initrd_start, ulong *initrd_end);
+          ulong *initrd_start, ulong *initrd_end);
 int boot_get_cmdline(struct lmb *lmb, ulong *cmd_start, ulong *cmd_end);
 #ifdef CONFIG_SYS_BOOT_GET_KBD
 int boot_get_kbd(struct lmb *lmb, bd_t **kbd);
@@ -686,40 +686,40 @@ int boot_get_kbd(struct lmb *lmb, bd_t **kbd);
 /*******************************************************************/
 static inline uint32_t image_get_header_size(void)
 {
-	return (sizeof(image_header_t));
+    return (sizeof(image_header_t));
 }
 
 #define image_get_hdr_l(f) \
-	static inline uint32_t image_get_##f(const image_header_t *hdr) \
-	{ \
-		return uimage_to_cpu(hdr->ih_##f); \
-	}
-image_get_hdr_l(magic)		/* image_get_magic */
-image_get_hdr_l(hcrc)		/* image_get_hcrc */
-image_get_hdr_l(time)		/* image_get_time */
-image_get_hdr_l(size)		/* image_get_size */
-image_get_hdr_l(load)		/* image_get_load */
-image_get_hdr_l(ep)		/* image_get_ep */
-image_get_hdr_l(dcrc)		/* image_get_dcrc */
+    static inline uint32_t image_get_##f(const image_header_t *hdr) \
+    { \
+        return uimage_to_cpu(hdr->ih_##f); \
+    }
+image_get_hdr_l(magic)      /* image_get_magic */
+image_get_hdr_l(hcrc)       /* image_get_hcrc */
+image_get_hdr_l(time)       /* image_get_time */
+image_get_hdr_l(size)       /* image_get_size */
+image_get_hdr_l(load)       /* image_get_load */
+image_get_hdr_l(ep)     /* image_get_ep */
+image_get_hdr_l(dcrc)       /* image_get_dcrc */
 
 #define image_get_hdr_b(f) \
-	static inline uint8_t image_get_##f(const image_header_t *hdr) \
-	{ \
-		return hdr->ih_##f; \
-	}
-image_get_hdr_b(os)		/* image_get_os */
-image_get_hdr_b(arch)		/* image_get_arch */
-image_get_hdr_b(type)		/* image_get_type */
-image_get_hdr_b(comp)		/* image_get_comp */
+    static inline uint8_t image_get_##f(const image_header_t *hdr) \
+    { \
+        return hdr->ih_##f; \
+    }
+image_get_hdr_b(os)     /* image_get_os */
+image_get_hdr_b(arch)       /* image_get_arch */
+image_get_hdr_b(type)       /* image_get_type */
+image_get_hdr_b(comp)       /* image_get_comp */
 
 static inline char *image_get_name(const image_header_t *hdr)
 {
-	return (char *)hdr->ih_name;
+    return (char *)hdr->ih_name;
 }
 
 static inline uint32_t image_get_data_size(const image_header_t *hdr)
 {
-	return image_get_size(hdr);
+    return image_get_size(hdr);
 }
 
 /**
@@ -735,44 +735,44 @@ static inline uint32_t image_get_data_size(const image_header_t *hdr)
  */
 static inline ulong image_get_data(const image_header_t *hdr)
 {
-	return ((ulong)hdr + image_get_header_size());
+    return ((ulong)hdr + image_get_header_size());
 }
 
 static inline uint32_t image_get_image_size(const image_header_t *hdr)
 {
-	return (image_get_size(hdr) + image_get_header_size());
+    return (image_get_size(hdr) + image_get_header_size());
 }
 static inline ulong image_get_image_end(const image_header_t *hdr)
 {
-	return ((ulong)hdr + image_get_image_size(hdr));
+    return ((ulong)hdr + image_get_image_size(hdr));
 }
 
 #define image_set_hdr_l(f) \
-	static inline void image_set_##f(image_header_t *hdr, uint32_t val) \
-	{ \
-		hdr->ih_##f = cpu_to_uimage(val); \
-	}
-image_set_hdr_l(magic)		/* image_set_magic */
-image_set_hdr_l(hcrc)		/* image_set_hcrc */
-image_set_hdr_l(time)		/* image_set_time */
-image_set_hdr_l(size)		/* image_set_size */
-image_set_hdr_l(load)		/* image_set_load */
-image_set_hdr_l(ep)		/* image_set_ep */
-image_set_hdr_l(dcrc)		/* image_set_dcrc */
+    static inline void image_set_##f(image_header_t *hdr, uint32_t val) \
+    { \
+        hdr->ih_##f = cpu_to_uimage(val); \
+    }
+image_set_hdr_l(magic)      /* image_set_magic */
+image_set_hdr_l(hcrc)       /* image_set_hcrc */
+image_set_hdr_l(time)       /* image_set_time */
+image_set_hdr_l(size)       /* image_set_size */
+image_set_hdr_l(load)       /* image_set_load */
+image_set_hdr_l(ep)     /* image_set_ep */
+image_set_hdr_l(dcrc)       /* image_set_dcrc */
 
 #define image_set_hdr_b(f) \
-	static inline void image_set_##f(image_header_t *hdr, uint8_t val) \
-	{ \
-		hdr->ih_##f = val; \
-	}
-image_set_hdr_b(os)		/* image_set_os */
-image_set_hdr_b(arch)		/* image_set_arch */
-image_set_hdr_b(type)		/* image_set_type */
-image_set_hdr_b(comp)		/* image_set_comp */
+    static inline void image_set_##f(image_header_t *hdr, uint8_t val) \
+    { \
+        hdr->ih_##f = val; \
+    }
+image_set_hdr_b(os)     /* image_set_os */
+image_set_hdr_b(arch)       /* image_set_arch */
+image_set_hdr_b(type)       /* image_set_type */
+image_set_hdr_b(comp)       /* image_set_comp */
 
 static inline void image_set_name(image_header_t *hdr, const char *name)
 {
-	strncpy(image_get_name(hdr), name, IH_NMLEN);
+    strncpy(image_get_name(hdr), name, IH_NMLEN);
 }
 
 int image_check_hcrc(const image_header_t *hdr);
@@ -786,24 +786,24 @@ void memmove_wd(void *to, void *from, size_t len, ulong chunksz);
 
 static inline int image_check_magic(const image_header_t *hdr)
 {
-	return (image_get_magic(hdr) == IH_MAGIC);
+    return (image_get_magic(hdr) == IH_MAGIC);
 }
 static inline int image_check_type(const image_header_t *hdr, uint8_t type)
 {
-	return (image_get_type(hdr) == type);
+    return (image_get_type(hdr) == type);
 }
 static inline int image_check_arch(const image_header_t *hdr, uint8_t arch)
 {
-	return (image_get_arch(hdr) == arch);
+    return (image_get_arch(hdr) == arch);
 }
 static inline int image_check_os(const image_header_t *hdr, uint8_t os)
 {
-	return (image_get_os(hdr) == os);
+    return (image_get_os(hdr) == os);
 }
 
 ulong image_multi_count(const image_header_t *hdr);
 void image_multi_getimg(const image_header_t *hdr, ulong idx,
-			ulong *data, ulong *len);
+            ulong *data, ulong *len);
 
 void image_print_contents(const void *hdr);
 
@@ -813,7 +813,7 @@ static inline int image_check_target_arch(const image_header_t *hdr)
 #ifndef IH_ARCH_DEFAULT
 # error "please define IH_ARCH_DEFAULT in your arch asm/u-boot.h"
 #endif
-	return image_check_arch(hdr, IH_ARCH_DEFAULT);
+    return image_check_arch(hdr, IH_ARCH_DEFAULT);
 }
 #endif /* USE_HOSTCC */
 
@@ -822,14 +822,14 @@ static inline int image_check_target_arch(const image_header_t *hdr)
  *
  * This sets up properties in the FDT that is to be passed to linux.
  *
- * @images:	Images information
- * @blob:	FDT to update
- * @of_size:	Size of the FDT
- * @lmb:	Points to logical memory block structure
+ * @images: Images information
+ * @blob:   FDT to update
+ * @of_size:    Size of the FDT
+ * @lmb:    Points to logical memory block structure
  * @return 0 if ok, <0 on failure
  */
 int image_setup_libfdt(bootm_headers_t *images, void *blob,
-		       int of_size, struct lmb *lmb);
+               int of_size, struct lmb *lmb);
 
 /**
  * Set up the FDT to use for booting a kernel
@@ -837,7 +837,7 @@ int image_setup_libfdt(bootm_headers_t *images, void *blob,
  * This performs ramdisk setup, sets up the FDT if required, and adds
  * paramters to the FDT if libfdt is available.
  *
- * @param images	Images information
+ * @param images    Images information
  * @return 0 if ok, <0 on failure
  */
 int image_setup_linux(bootm_headers_t *images);
@@ -857,44 +857,46 @@ int bootz_setup(ulong image, ulong *start, ulong *end);
 /* New uImage format specific code (prefixed with fit_) */
 /*******************************************************************/
 
-#define FIT_IMAGES_PATH		"/images"
-#define FIT_CONFS_PATH		"/configurations"
+#define FIT_IMAGES_PATH     "/images"
+#define FIT_CONFS_PATH      "/configurations"
 
 /* hash/signature node */
-#define FIT_HASH_NODENAME	"hash"
-#define FIT_ALGO_PROP		"algo"
-#define FIT_VALUE_PROP		"value"
-#define FIT_IGNORE_PROP		"uboot-ignore"
-#define FIT_SIG_NODENAME	"signature"
+#define FIT_HASH_NODENAME   "hash"
+#define FIT_ALGO_PROP       "algo"
+#define FIT_VALUE_PROP      "value"
+#define FIT_IGNORE_PROP     "uboot-ignore"
+#define FIT_SIG_NODENAME    "signature"
 
 /* image node */
-#define FIT_DATA_PROP		"data"
-#define FIT_TIMESTAMP_PROP	"timestamp"
-#define FIT_DESC_PROP		"description"
-#define FIT_ARCH_PROP		"arch"
-#define FIT_TYPE_PROP		"type"
-#define FIT_OS_PROP		"os"
-#define FIT_COMP_PROP		"compression"
-#define FIT_ENTRY_PROP		"entry"
-#define FIT_LOAD_PROP		"load"
+#define FIT_DATA_PROP       "data"
+#define FIT_DATA_OFFSET_PROP "data-offset"
+#define FIT_DATA_SIZE_PROP  "data-size"
+#define FIT_TIMESTAMP_PROP  "timestamp"
+#define FIT_DESC_PROP       "description"
+#define FIT_ARCH_PROP       "arch"
+#define FIT_TYPE_PROP       "type"
+#define FIT_OS_PROP     "os"
+#define FIT_COMP_PROP       "compression"
+#define FIT_ENTRY_PROP      "entry"
+#define FIT_LOAD_PROP       "load"
 
 /* configuration node */
-#define FIT_KERNEL_PROP		"kernel"
-#define FIT_RAMDISK_PROP	"ramdisk"
-#define FIT_FDT_PROP		"fdt"
-#define FIT_LOADABLE_PROP	"loadables"
-#define FIT_DEFAULT_PROP	"default"
-#define FIT_SETUP_PROP		"setup"
-#define FIT_FPGA_PROP		"fpga"
+#define FIT_KERNEL_PROP     "kernel"
+#define FIT_RAMDISK_PROP    "ramdisk"
+#define FIT_FDT_PROP        "fdt"
+#define FIT_LOADABLE_PROP   "loadables"
+#define FIT_DEFAULT_PROP    "default"
+#define FIT_SETUP_PROP      "setup"
+#define FIT_FPGA_PROP       "fpga"
 
-#define FIT_MAX_HASH_LEN	HASH_MAX_DIGEST_SIZE
+#define FIT_MAX_HASH_LEN    HASH_MAX_DIGEST_SIZE
 
 #if IMAGE_ENABLE_FIT
 /* cmdline argument format parsing */
 int fit_parse_conf(const char *spec, ulong addr_curr,
-		ulong *addr, const char **conf_name);
+        ulong *addr, const char **conf_name);
 int fit_parse_subimage(const char *spec, ulong addr_curr,
-		ulong *addr, const char **image_name);
+        ulong *addr, const char **image_name);
 
 int fit_get_subimage_count(const void *fit, int images_noffset);
 void fit_print_contents(const void *fit);
@@ -909,7 +911,7 @@ void fit_image_print(const void *fit, int noffset, const char *p);
  */
 static inline ulong fit_get_size(const void *fit)
 {
-	return fdt_totalsize(fit);
+    return fdt_totalsize(fit);
 }
 
 /**
@@ -930,9 +932,9 @@ ulong fit_get_end(const void *fit);
  *     pointer to node name, on success
  */
 static inline const char *fit_get_name(const void *fit_hdr,
-		int noffset, int *len)
+        int noffset, int *len)
 {
-	return fdt_get_name(fit_hdr, noffset, len);
+    return fdt_get_name(fit_hdr, noffset, len);
 }
 
 int fit_get_desc(const void *fit, int noffset, char **desc);
@@ -946,21 +948,23 @@ int fit_image_get_comp(const void *fit, int noffset, uint8_t *comp);
 int fit_image_get_load(const void *fit, int noffset, ulong *load);
 int fit_image_get_entry(const void *fit, int noffset, ulong *entry);
 int fit_image_get_data(const void *fit, int noffset,
-				const void **data, size_t *size);
+                const void **data, size_t *size);
+int fit_image_get_data_offset(const void *fit, int noffset, int *data_offset);
+int fit_image_get_data_size(const void *fit, int noffset, int *data_size);
 
 int fit_image_hash_get_algo(const void *fit, int noffset, char **algo);
 int fit_image_hash_get_value(const void *fit, int noffset, uint8_t **value,
-				int *value_len);
+                int *value_len);
 
 int fit_set_timestamp(void *fit, int noffset, time_t timestamp);
 
 /**
  * fit_add_verification_data() - add verification data to FIT image nodes
  *
- * @keydir:	Directory containing keys
- * @kwydest:	FDT blob to write public key information to
- * @fit:	Pointer to the FIT format image header
- * @comment:	Comment to add to signature nodes
+ * @keydir: Directory containing keys
+ * @kwydest:    FDT blob to write public key information to
+ * @fit:    Pointer to the FIT format image header
+ * @comment:    Comment to add to signature nodes
  * @require_keys: Mark all keys as 'required'
  *
  * Adds hash values for all component images in the FIT blob.
@@ -974,7 +978,7 @@ int fit_set_timestamp(void *fit, int noffset, time_t timestamp);
  *     libfdt error code, on failure
  */
 int fit_add_verification_data(const char *keydir, void *keydest, void *fit,
-			      const char *comment, int require_keys);
+                  const char *comment, int require_keys);
 
 int fit_image_verify(const void *fit, int noffset);
 int fit_config_verify(const void *fit, int conf_noffset);
@@ -990,9 +994,9 @@ int fit_conf_get_node(const void *fit, const char *conf_uname);
 
 /**
  * fit_conf_get_prop_node() - Get node refered to by a configuration
- * @fit:	FIT to check
- * @noffset:	Offset of conf@xxx node to check
- * @prop_name:	Property to read from the conf node
+ * @fit:    FIT to check
+ * @noffset:    Offset of conf@xxx node to check
+ * @prop_name:  Property to read from the conf node
  *
  * The conf@ nodes contain references to other nodes, using properties
  * like 'kernel = "kernel@1"'. Given such a property name (e.g. "kernel"),
@@ -1000,15 +1004,15 @@ int fit_conf_get_node(const void *fit, const char *conf_uname);
  * "/images/kernel@1".
  */
 int fit_conf_get_prop_node(const void *fit, int noffset,
-		const char *prop_name);
+        const char *prop_name);
 
 void fit_conf_print(const void *fit, int noffset, const char *p);
 
 int fit_check_ramdisk(const void *fit, int os_noffset,
-		uint8_t arch, int verify);
+        uint8_t arch, int verify);
 
 int calculate_hash(const void *data, int data_len, const char *algo,
-			uint8_t *value, int *value_len);
+            uint8_t *value, int *value_len);
 
 /*
  * At present we only support signing on the host, and verification on the
@@ -1016,49 +1020,49 @@ int calculate_hash(const void *data, int data_len, const char *algo,
  */
 #if defined(CONFIG_FIT_SIGNATURE)
 # ifdef USE_HOSTCC
-#  define IMAGE_ENABLE_SIGN	1
-#  define IMAGE_ENABLE_VERIFY	1
+#  define IMAGE_ENABLE_SIGN 1
+#  define IMAGE_ENABLE_VERIFY   1
 # include  <openssl/evp.h>
 #else
-#  define IMAGE_ENABLE_SIGN	0
-#  define IMAGE_ENABLE_VERIFY	1
+#  define IMAGE_ENABLE_SIGN 0
+#  define IMAGE_ENABLE_VERIFY   1
 # endif
 #else
-# define IMAGE_ENABLE_SIGN	0
-# define IMAGE_ENABLE_VERIFY	0
+# define IMAGE_ENABLE_SIGN  0
+# define IMAGE_ENABLE_VERIFY    0
 #endif
 
 #ifdef USE_HOSTCC
 void *image_get_host_blob(void);
 void image_set_host_blob(void *host_blob);
-# define gd_fdt_blob()		image_get_host_blob()
+# define gd_fdt_blob()      image_get_host_blob()
 #else
-# define gd_fdt_blob()		(gd->fdt_blob)
+# define gd_fdt_blob()      (gd->fdt_blob)
 #endif
 
 #ifdef CONFIG_FIT_BEST_MATCH
-#define IMAGE_ENABLE_BEST_MATCH	1
+#define IMAGE_ENABLE_BEST_MATCH 1
 #else
-#define IMAGE_ENABLE_BEST_MATCH	0
+#define IMAGE_ENABLE_BEST_MATCH 0
 #endif
 
 /* Information passed to the signing routines */
 struct image_sign_info {
-	const char *keydir;		/* Directory conaining keys */
-	const char *keyname;		/* Name of key to use */
-	void *fit;			/* Pointer to FIT blob */
-	int node_offset;		/* Offset of signature node */
-	struct image_sig_algo *algo;	/* Algorithm information */
-	const void *fdt_blob;		/* FDT containing public keys */
-	int required_keynode;		/* Node offset of key to use: -1=any */
-	const char *require_keys;	/* Value for 'required' property */
+    const char *keydir;     /* Directory conaining keys */
+    const char *keyname;        /* Name of key to use */
+    void *fit;          /* Pointer to FIT blob */
+    int node_offset;        /* Offset of signature node */
+    struct image_sig_algo *algo;    /* Algorithm information */
+    const void *fdt_blob;       /* FDT containing public keys */
+    int required_keynode;       /* Node offset of key to use: -1=any */
+    const char *require_keys;   /* Value for 'required' property */
 };
 #endif /* Allow struct image_region to always be defined for rsa.h */
 
 /* A part of an image, used for hashing */
 struct image_region {
-	const void *data;
-	int size;
+    const void *data;
+    int size;
 };
 
 #if IMAGE_ENABLE_FIT
@@ -1067,77 +1071,77 @@ struct image_region {
 # include <u-boot/rsa-checksum.h>
 #endif
 struct checksum_algo {
-	const char *name;
-	const int checksum_len;
-	const int pad_len;
+    const char *name;
+    const int checksum_len;
+    const int pad_len;
 #if IMAGE_ENABLE_SIGN
-	const EVP_MD *(*calculate_sign)(void);
+    const EVP_MD *(*calculate_sign)(void);
 #endif
-	int (*calculate)(const char *name,
-			 const struct image_region region[],
-			 int region_count, uint8_t *checksum);
-	const uint8_t *rsa_padding;
+    int (*calculate)(const char *name,
+             const struct image_region region[],
+             int region_count, uint8_t *checksum);
+    const uint8_t *rsa_padding;
 };
 
 struct image_sig_algo {
-	const char *name;		/* Name of algorithm */
+    const char *name;       /* Name of algorithm */
 
-	/**
-	 * sign() - calculate and return signature for given input data
-	 *
-	 * @info:	Specifies key and FIT information
-	 * @data:	Pointer to the input data
-	 * @data_len:	Data length
-	 * @sigp:	Set to an allocated buffer holding the signature
-	 * @sig_len:	Set to length of the calculated hash
-	 *
-	 * This computes input data signature according to selected algorithm.
-	 * Resulting signature value is placed in an allocated buffer, the
-	 * pointer is returned as *sigp. The length of the calculated
-	 * signature is returned via the sig_len pointer argument. The caller
-	 * should free *sigp.
-	 *
-	 * @return: 0, on success, -ve on error
-	 */
-	int (*sign)(struct image_sign_info *info,
-		    const struct image_region region[],
-		    int region_count, uint8_t **sigp, uint *sig_len);
+    /**
+     * sign() - calculate and return signature for given input data
+     *
+     * @info:   Specifies key and FIT information
+     * @data:   Pointer to the input data
+     * @data_len:   Data length
+     * @sigp:   Set to an allocated buffer holding the signature
+     * @sig_len:    Set to length of the calculated hash
+     *
+     * This computes input data signature according to selected algorithm.
+     * Resulting signature value is placed in an allocated buffer, the
+     * pointer is returned as *sigp. The length of the calculated
+     * signature is returned via the sig_len pointer argument. The caller
+     * should free *sigp.
+     *
+     * @return: 0, on success, -ve on error
+     */
+    int (*sign)(struct image_sign_info *info,
+            const struct image_region region[],
+            int region_count, uint8_t **sigp, uint *sig_len);
 
-	/**
-	 * add_verify_data() - Add verification information to FDT
-	 *
-	 * Add public key information to the FDT node, suitable for
-	 * verification at run-time. The information added depends on the
-	 * algorithm being used.
-	 *
-	 * @info:	Specifies key and FIT information
-	 * @keydest:	Destination FDT blob for public key data
-	 * @return: 0, on success, -ve on error
-	 */
-	int (*add_verify_data)(struct image_sign_info *info, void *keydest);
+    /**
+     * add_verify_data() - Add verification information to FDT
+     *
+     * Add public key information to the FDT node, suitable for
+     * verification at run-time. The information added depends on the
+     * algorithm being used.
+     *
+     * @info:   Specifies key and FIT information
+     * @keydest:    Destination FDT blob for public key data
+     * @return: 0, on success, -ve on error
+     */
+    int (*add_verify_data)(struct image_sign_info *info, void *keydest);
 
-	/**
-	 * verify() - Verify a signature against some data
-	 *
-	 * @info:	Specifies key and FIT information
-	 * @data:	Pointer to the input data
-	 * @data_len:	Data length
-	 * @sig:	Signature
-	 * @sig_len:	Number of bytes in signature
-	 * @return 0 if verified, -ve on error
-	 */
-	int (*verify)(struct image_sign_info *info,
-		      const struct image_region region[], int region_count,
-		      uint8_t *sig, uint sig_len);
+    /**
+     * verify() - Verify a signature against some data
+     *
+     * @info:   Specifies key and FIT information
+     * @data:   Pointer to the input data
+     * @data_len:   Data length
+     * @sig:    Signature
+     * @sig_len:    Number of bytes in signature
+     * @return 0 if verified, -ve on error
+     */
+    int (*verify)(struct image_sign_info *info,
+              const struct image_region region[], int region_count,
+              uint8_t *sig, uint sig_len);
 
-	/* pointer to checksum algorithm */
-	struct checksum_algo *checksum;
+    /* pointer to checksum algorithm */
+    struct checksum_algo *checksum;
 };
 
 /**
  * image_get_sig_algo() - Look up a signature algortihm
  *
- * @param name		Name of algorithm
+ * @param name      Name of algorithm
  * @return pointer to algorithm information, or NULL if not found
  */
 struct image_sig_algo *image_get_sig_algo(const char *name);
@@ -1145,38 +1149,38 @@ struct image_sig_algo *image_get_sig_algo(const char *name);
 /**
  * fit_image_verify_required_sigs() - Verify signatures marked as 'required'
  *
- * @fit:		FIT to check
- * @image_noffset:	Offset of image node to check
- * @data:		Image data to check
- * @size:		Size of image data
- * @sig_blob:		FDT containing public keys
- * @no_sigsp:		Returns 1 if no signatures were required, and
- *			therefore nothing was checked. The caller may wish
- *			to fall back to other mechanisms, or refuse to
- *			boot.
+ * @fit:        FIT to check
+ * @image_noffset:  Offset of image node to check
+ * @data:       Image data to check
+ * @size:       Size of image data
+ * @sig_blob:       FDT containing public keys
+ * @no_sigsp:       Returns 1 if no signatures were required, and
+ *          therefore nothing was checked. The caller may wish
+ *          to fall back to other mechanisms, or refuse to
+ *          boot.
  * @return 0 if all verified ok, <0 on error
  */
 int fit_image_verify_required_sigs(const void *fit, int image_noffset,
-		const char *data, size_t size, const void *sig_blob,
-		int *no_sigsp);
+        const char *data, size_t size, const void *sig_blob,
+        int *no_sigsp);
 
 /**
  * fit_image_check_sig() - Check a single image signature node
  *
- * @fit:		FIT to check
- * @noffset:		Offset of signature node to check
- * @data:		Image data to check
- * @size:		Size of image data
- * @required_keynode:	Offset in the control FDT of the required key node,
- *			if any. If this is given, then the image wil not
- *			pass verification unless that key is used. If this is
- *			-1 then any signature will do.
- * @err_msgp:		In the event of an error, this will be pointed to a
- *			help error string to display to the user.
+ * @fit:        FIT to check
+ * @noffset:        Offset of signature node to check
+ * @data:       Image data to check
+ * @size:       Size of image data
+ * @required_keynode:   Offset in the control FDT of the required key node,
+ *          if any. If this is given, then the image wil not
+ *          pass verification unless that key is used. If this is
+ *          -1 then any signature will do.
+ * @err_msgp:       In the event of an error, this will be pointed to a
+ *          help error string to display to the user.
  * @return 0 if all verified ok, <0 on error
  */
 int fit_image_check_sig(const void *fit, int noffset, const void *data,
-		size_t size, int required_keynode, char **err_msgp);
+        size_t size, int required_keynode, char **err_msgp);
 
 /**
  * fit_region_make_list() - Make a list of regions to hash
@@ -1185,34 +1189,34 @@ int fit_image_check_sig(const void *fit, int noffset, const void *data,
  * a list of regions (void *, size) for use by the signature creationg
  * and verification code.
  *
- * @fit:		FIT image to process
- * @fdt_regions:	Regions as returned by libfdt
- * @count:		Number of regions returned by libfdt
- * @region:		Place to put list of regions (NULL to allocate it)
+ * @fit:        FIT image to process
+ * @fdt_regions:    Regions as returned by libfdt
+ * @count:      Number of regions returned by libfdt
+ * @region:     Place to put list of regions (NULL to allocate it)
  * @return pointer to list of regions, or NULL if out of memory
  */
 struct image_region *fit_region_make_list(const void *fit,
-		struct fdt_region *fdt_regions, int count,
-		struct image_region *region);
+        struct fdt_region *fdt_regions, int count,
+        struct image_region *region);
 
 static inline int fit_image_check_target_arch(const void *fdt, int node)
 {
 #ifndef USE_HOSTCC
-	return fit_image_check_arch(fdt, node, IH_ARCH_DEFAULT);
+    return fit_image_check_arch(fdt, node, IH_ARCH_DEFAULT);
 #else
-	return 0;
+    return 0;
 #endif
 }
 
 #ifdef CONFIG_FIT_VERBOSE
-#define fit_unsupported(msg)	printf("! %s:%d " \
-				"FIT images not supported for '%s'\n", \
-				__FILE__, __LINE__, (msg))
+#define fit_unsupported(msg)    printf("! %s:%d " \
+                "FIT images not supported for '%s'\n", \
+                __FILE__, __LINE__, (msg))
 
-#define fit_unsupported_reset(msg)	printf("! %s:%d " \
-				"FIT images not supported for '%s' " \
-				"- must reset board to recover!\n", \
-				__FILE__, __LINE__, (msg))
+#define fit_unsupported_reset(msg)  printf("! %s:%d " \
+                "FIT images not supported for '%s' " \
+                "- must reset board to recover!\n", \
+                __FILE__, __LINE__, (msg))
 #else
 #define fit_unsupported(msg)
 #define fit_unsupported_reset(msg)
@@ -1223,9 +1227,9 @@ static inline int fit_image_check_target_arch(const void *fdt, int node)
 struct andr_img_hdr;
 int android_image_check_header(const struct andr_img_hdr *hdr);
 int android_image_get_kernel(const struct andr_img_hdr *hdr, int verify,
-			     ulong *os_data, ulong *os_len);
+                 ulong *os_data, ulong *os_len);
 int android_image_get_ramdisk(const struct andr_img_hdr *hdr,
-			      ulong *rd_data, ulong *rd_len);
+                  ulong *rd_data, ulong *rd_len);
 ulong android_image_get_end(const struct andr_img_hdr *hdr);
 ulong android_image_get_kload(const struct andr_img_hdr *hdr);
 void android_print_contents(const struct andr_img_hdr *hdr);
@@ -1262,4 +1266,4 @@ int board_fit_config_name_match(const char *name);
 void board_fit_image_post_process(void **p_image, size_t *p_size);
 #endif /* CONFIG_SPL_FIT_IMAGE_POST_PROCESS */
 
-#endif	/* __IMAGE_H__ */
+#endif  /* __IMAGE_H__ */

--- a/lib/libfdt/fdt.c
+++ b/lib/libfdt/fdt.c
@@ -16,6 +16,9 @@
 
 int fdt_check_header(const void *fdt)
 {
+	if (fdt == NULL) {
+		return -FDT_ERR_BADOFFSET;
+	}
 	if (fdt_magic(fdt) == FDT_MAGIC) {
 		/* Complete tree */
 		if (fdt_version(fdt) < FDT_FIRST_SUPPORTED_VERSION)


### PR DESCRIPTION
Updating our upgrade logic to reduce the amount of RAM required. Instead of loading the entire upgrade file into RAM, we'll now load the upgrade headers, followed by the individual upgrade entities (kernel, rootfs).

Old upgrade files looked like this:

|                                     |
|-------------------------|
| Header                        |
| Node header (kernel) |
| Kernel data (2.5M)      |
| Node header (rootfs) |
| Rootfs data (20M)      |
| String section             |

(The string section contains data which is needed in order to properly decode the headers)

We're now expecting that upgrade files will be generated using `mkimage`'s `-E` option, which moves the data sections to the end of the file (as far as the file header is concerned, the data sections are now external, so are not included in the `total_size` parameter). This will require changes to the board configurations in kubos/kubos-linux-build in order to be compatible

New upgrade files look like this:

|                                     |
|-------------------------|
| Header                        |
| Node header (kernel) |
| Node header (rootfs) |
| String section             |
| Kernel data (2.5M)      |
| Rootfs data (20M)      |

Some work was needed in other files in order to allow us to use offsets in various places. This work was already completed in the latest U-Boot release, so I copied the solutions from there.