### PR TITLE
Improving error behavior

### DIFF
--- a/common/autoboot.c
+++ b/common/autoboot.c
@@ -359,6 +359,18 @@ void autoboot_command(const char *s)
 #if defined(CONFIG_AUTOBOOT_KEYED) && !defined(CONFIG_AUTOBOOT_KEYED_CTRLC)
 		disable_ctrlc(prev);	/* restore Control C checking */
 #endif
+
+		/*
+		 * We failed to run commands for some reason.
+		 * There are two conceivable reasons:
+		 * - Someone coded bad boot commands
+		 * - The envar section of RAM got hit with an SEU
+		 *
+		 * We want to try to handle the latter by just doing a system reset so
+		 * that RAM gets reloaded
+		 */
+
+		do_reset(cmdtp, flag, argc, argv);
 	}
 
 #ifdef CONFIG_MENUKEY

--- a/include/configs/kubos-common.h
+++ b/include/configs/kubos-common.h
@@ -44,7 +44,7 @@
 #define KUBOS_UPDATE_FILE  "kubos_updatefile"
 
 #define KUBOS_UPDATE_ARGS \
-	"altbootcmd=setenv recovery_available 0; setenv bootcmd; saveenv\0" \
+	"altbootcmd=run bootcmd\0" \
 	"recovery_available=1\0" \
     "bootlimit=3\0" \
 	KUBOS_CURR_VERSION "=" KUBOS_BASE "\0" \


### PR DESCRIPTION
Currently when U-Boot goes through the boot process, one of three things is likely to happen:
- System boots successfully
- System fails to boot and enters our recovery logic
- System fails to boot and goes to the U-Boot CLI

We would like the system to never go to the CLI (except via manual user intervention), so this PR updates a few places to trigger a reboot instead.

Additionally, `altbootcmd` will just call the normal bootcmd by default, instead of going to the CLI