### PR TITLE
Updating upgrade DTB file names for BBB/MBM2

### DIFF
--- a/include/configs/beaglebone-black.h
+++ b/include/configs/beaglebone-black.h
@@ -67,7 +67,7 @@
     "kernel fat 1 1;"       \
     "rootfs part 1 2;" \
     "uboot fat 1 1;" \
-    "dtb fat 1 1" \
+    "beaglebone-black.dtb fat 1 1" \
     "\0"
 
 #define DFU_ALT_INFO_NOR ""

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -68,7 +68,7 @@
 	"kernel fat 1 1;" 		\
 	"rootfs part 1 2;" \
 	"uboot fat 1 1;" \
-	"dtb fat 1 1" \
+	"pumpkin-mbm2.dtb fat 1 1" \
 	"\0"
 
 #define DFU_ALT_INFO_NOR ""


### PR DESCRIPTION
The device tree files for the BBB and MBM2 are [loaded by name](https://github.com/kubos/uboot/blob/master/include/configs/beaglebone-black.h#L102) during the boot process. (The iOBC loads its device tree [by address](https://github.com/kubos/uboot/blob/master/include/configs/at91sam9g20isis.h#L228), not name)

Turns out the upgrade-able file definitions use the name at the beginning of the definition as the final file name.

This PR updates the BBB and MBM2 definitions to explicitly/correctly name their DTB files